### PR TITLE
Add VerifyInvocationAsync overload for context property injection

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <!-- Shared package/library version for ZcapLd.Core and ZcapLd.AspNetCore -->
-    <ZcapLdVersion>0.3.2</ZcapLdVersion>
+    <ZcapLdVersion>0.3.3</ZcapLdVersion>
   </PropertyGroup>
 </Project>

--- a/examples/ZcapLd.Examples/ContentTypeCaveat.cs
+++ b/examples/ZcapLd.Examples/ContentTypeCaveat.cs
@@ -1,0 +1,21 @@
+using ZcapLd.Core.Models;
+
+namespace ZcapLd.Examples;
+
+/// <summary>
+/// Example custom caveat that enforces a required HTTP Content-Type.
+/// Reads "contentType" from <see cref="InvocationContext.Properties"/>,
+/// which the caller injects via the 3-param VerifyInvocationAsync overload.
+/// </summary>
+public class ContentTypeCaveat : Caveat
+{
+    public override string Type => "ContentType";
+    public string RequiredContentType { get; set; } = string.Empty;
+
+    public override bool IsSatisfied(InvocationContext context)
+    {
+        return context.Properties.TryGetValue("contentType", out var value)
+            && value is string contentType
+            && string.Equals(contentType, RequiredContentType, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/examples/ZcapLd.Examples/Program.cs
+++ b/examples/ZcapLd.Examples/Program.cs
@@ -457,6 +457,95 @@ var revokedResult = await revokedVerifier.VerifyInvocationAsync(partnerInvocatio
 Console.WriteLine($"    Invocation valid: {revokedResult} (expected: False — capability revoked)");
 
 Console.WriteLine();
+
+// ===================================================
+// Example 9: Context Property Injection for Custom Caveats
+// ===================================================
+Console.WriteLine("Example 9: Context Property Injection for Custom Caveats");
+Console.WriteLine("---------------------------------------------------------");
+
+// Custom caveats often need application-specific metadata that isn't part of
+// the invocation document itself (e.g. HTTP Content-Type, schema URI, caller IP).
+// The 3-param VerifyInvocationAsync overload lets callers inject these properties
+// into InvocationContext.Properties, where custom caveats can read them.
+
+var apiOwnerDid = "did:key:z6MkApiOwner";
+var clientDid = "did:key:z6MkClient";
+didProvider.GenerateAndRegisterKeyPair(apiOwnerDid);
+didProvider.GenerateAndRegisterKeyPair(clientDid);
+
+// Create root capability for an API that only accepts JSON payloads
+var jsonApiRoot = await capabilityService.CreateRootCapabilityAsync(
+    controller: apiOwnerDid,
+    invocationTarget: "https://api.example.com/v1/records",
+    allowedActions: new[] { "read", "write" }
+);
+
+// Delegate to the client with a ContentType caveat requiring application/json
+var clientCapability = await capabilityService.DelegateCapabilityAsync(
+    parentCapability: jsonApiRoot,
+    newController: clientDid,
+    allowedActions: new[] { "write" },
+    expires: DateTime.UtcNow.AddDays(7),
+    caveats: new Caveat[]
+    {
+        new ContentTypeCaveat { RequiredContentType = "application/json" }
+    }
+);
+
+Console.WriteLine($"Delegated to client: {clientCapability.Id}");
+Console.WriteLine($"  Actions: {string.Join(", ", clientCapability.AllowedAction)}");
+Console.WriteLine($"  Caveat: ContentType must be application/json");
+
+// Client invokes the capability
+var clientInvocation = new Invocation
+{
+    Capability = clientCapability.Id,
+    CapabilityAction = "write",
+    InvocationTarget = "https://api.example.com/v1/records"
+};
+clientInvocation.Proof = await signingService.SignInvocationAsync(clientInvocation, clientDid);
+
+// Verify WITH correct content type injected from the HTTP request context
+Console.WriteLine("\n  With contentType = application/json:");
+var jsonResult = await verificationService.VerifyInvocationAsync(
+    clientInvocation,
+    clientCapability,
+    new Dictionary<string, object> { ["contentType"] = "application/json" });
+Console.WriteLine($"    Invocation valid: {jsonResult} (expected: True)");
+
+// Re-sign with fresh nonce, then verify with wrong content type
+var clientInvocation2 = new Invocation
+{
+    Capability = clientCapability.Id,
+    CapabilityAction = "write",
+    InvocationTarget = "https://api.example.com/v1/records"
+};
+clientInvocation2.Proof = await signingService.SignInvocationAsync(clientInvocation2, clientDid);
+
+Console.WriteLine("\n  With contentType = text/xml:");
+var xmlResult = await verificationService.VerifyInvocationAsync(
+    clientInvocation2,
+    clientCapability,
+    new Dictionary<string, object> { ["contentType"] = "text/xml" });
+Console.WriteLine($"    Invocation valid: {xmlResult} (expected: False — wrong content type)");
+
+// Re-sign with fresh nonce, then verify without any properties (caveat will reject)
+var clientInvocation3 = new Invocation
+{
+    Capability = clientCapability.Id,
+    CapabilityAction = "write",
+    InvocationTarget = "https://api.example.com/v1/records"
+};
+clientInvocation3.Proof = await signingService.SignInvocationAsync(clientInvocation3, clientDid);
+
+Console.WriteLine("\n  Without context properties (fail-closed):");
+var noPropsResult = await verificationService.VerifyInvocationAsync(
+    clientInvocation3,
+    clientCapability);
+Console.WriteLine($"    Invocation valid: {noPropsResult} (expected: False — no properties injected)");
+
+Console.WriteLine();
 Console.WriteLine("===========================================");
 Console.WriteLine("All examples completed successfully!");
 Console.WriteLine("===========================================");

--- a/src/ZcapLd.Core/Services/IVerificationService.cs
+++ b/src/ZcapLd.Core/Services/IVerificationService.cs
@@ -23,6 +23,17 @@ public interface IVerificationService
     Task<bool> VerifyInvocationAsync(Invocation invocation, Capability capability);
 
     /// <summary>
+    /// Verifies an invocation request with application-specific context properties.
+    /// Properties are merged into <see cref="InvocationContext.Properties"/> before caveat evaluation,
+    /// enabling custom caveats to read request-scoped metadata (e.g. content type, schema URI, caller IP).
+    /// </summary>
+    /// <param name="invocation">The invocation to verify</param>
+    /// <param name="capability">The capability being invoked</param>
+    /// <param name="contextProperties">Application-specific key/value pairs to inject into the invocation context</param>
+    /// <returns>True if the invocation is valid</returns>
+    Task<bool> VerifyInvocationAsync(Invocation invocation, Capability capability, Dictionary<string, object>? contextProperties);
+
+    /// <summary>
     /// Verifies a capability delegation chain
     /// </summary>
     /// <param name="capability">The capability with delegation chain</param>

--- a/src/ZcapLd.Core/Services/VerificationService.cs
+++ b/src/ZcapLd.Core/Services/VerificationService.cs
@@ -191,7 +191,14 @@ public class VerificationService : IVerificationService
     /// Verifies an invocation request
     /// SECURITY FIX S-04: Added validation for invocation ID (replay protection)
     /// </summary>
-    public async Task<bool> VerifyInvocationAsync(Invocation invocation, Capability capability)
+    public Task<bool> VerifyInvocationAsync(Invocation invocation, Capability capability)
+        => VerifyInvocationAsync(invocation, capability, contextProperties: null);
+
+    /// <inheritdoc />
+    public async Task<bool> VerifyInvocationAsync(
+        Invocation invocation,
+        Capability capability,
+        Dictionary<string, object>? contextProperties)
     {
         if (invocation == null)
             throw new ArgumentNullException(nameof(invocation));
@@ -260,6 +267,15 @@ public class VerificationService : IVerificationService
                 RequestedAction = invocation.CapabilityAction,
                 TargetResource = invocation.InvocationTarget
             };
+
+            // Merge caller-provided properties into the invocation context
+            if (contextProperties != null)
+            {
+                foreach (var kvp in contextProperties)
+                {
+                    context.Properties[kvp.Key] = kvp.Value;
+                }
+            }
 
             // Evaluate all caveats from the complete chain (not just leaf)
             if (!await _caveatProcessor.EvaluateCapabilityChainCaveatsAsync(chain.ToArray(), context))

--- a/tests/ZcapLd.Core.Tests/Services/VerificationServiceTests.cs
+++ b/tests/ZcapLd.Core.Tests/Services/VerificationServiceTests.cs
@@ -735,6 +735,139 @@ public class VerificationServiceTests
         result.Should().BeFalse(); // Caveat should cause failure
     }
 
+    [Fact]
+    public async Task VerifyInvocation_WithContextProperties_ShouldPassToCustomCaveat()
+    {
+        // Arrange
+        var controllerDid = "did:key:z6MkController";
+        _didProvider.GenerateAndRegisterKeyPair(controllerDid);
+
+        var caveat = new ContentTypeCaveat { RequiredContentType = "application/json" };
+
+        var rootCapability = await _capabilityService.CreateRootCapabilityAsync(
+            controllerDid,
+            "https://example.com/resource",
+            new[] { "write" });
+
+        var delegatedCapability = await _capabilityService.DelegateCapabilityAsync(
+            rootCapability,
+            controllerDid,
+            new[] { "write" },
+            DateTime.UtcNow.AddDays(5),
+            new Caveat[] { caveat });
+
+        var invocation = new Invocation
+        {
+            Capability = delegatedCapability.Id,
+            CapabilityAction = "write",
+            InvocationTarget = "https://example.com/resource"
+        };
+        invocation.Proof = await _signingService.SignInvocationAsync(invocation, controllerDid);
+
+        // Act — inject the property the caveat expects
+        var result = await _verificationService.VerifyInvocationAsync(
+            invocation,
+            delegatedCapability,
+            new Dictionary<string, object> { ["contentType"] = "application/json" });
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task VerifyInvocation_WithContextProperties_WrongValue_ShouldReturnFalse()
+    {
+        // Arrange
+        var controllerDid = "did:key:z6MkController";
+        _didProvider.GenerateAndRegisterKeyPair(controllerDid);
+
+        var caveat = new ContentTypeCaveat { RequiredContentType = "application/json" };
+
+        var rootCapability = await _capabilityService.CreateRootCapabilityAsync(
+            controllerDid,
+            "https://example.com/resource",
+            new[] { "write" });
+
+        var delegatedCapability = await _capabilityService.DelegateCapabilityAsync(
+            rootCapability,
+            controllerDid,
+            new[] { "write" },
+            DateTime.UtcNow.AddDays(5),
+            new Caveat[] { caveat });
+
+        var invocation = new Invocation
+        {
+            Capability = delegatedCapability.Id,
+            CapabilityAction = "write",
+            InvocationTarget = "https://example.com/resource"
+        };
+        invocation.Proof = await _signingService.SignInvocationAsync(invocation, controllerDid);
+
+        // Act — inject a wrong content type
+        var result = await _verificationService.VerifyInvocationAsync(
+            invocation,
+            delegatedCapability,
+            new Dictionary<string, object> { ["contentType"] = "text/plain" });
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task VerifyInvocation_WithNullContextProperties_ShouldSucceed()
+    {
+        // Arrange — same setup as valid invocation, but call the 3-param overload with null
+        var controllerDid = "did:key:z6MkController";
+        _didProvider.GenerateAndRegisterKeyPair(controllerDid);
+
+        var rootCapability = await _capabilityService.CreateRootCapabilityAsync(
+            controllerDid,
+            "https://example.com/resource",
+            new[] { "read" });
+
+        var invocation = new Invocation
+        {
+            Capability = rootCapability.Id,
+            CapabilityAction = "read",
+            InvocationTarget = "https://example.com/resource"
+        };
+        invocation.Proof = await _signingService.SignInvocationAsync(invocation, controllerDid);
+
+        // Act
+        var result = await _verificationService.VerifyInvocationAsync(invocation, rootCapability, null);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task VerifyInvocation_WithEmptyContextProperties_ShouldSucceed()
+    {
+        // Arrange
+        var controllerDid = "did:key:z6MkController";
+        _didProvider.GenerateAndRegisterKeyPair(controllerDid);
+
+        var rootCapability = await _capabilityService.CreateRootCapabilityAsync(
+            controllerDid,
+            "https://example.com/resource",
+            new[] { "read" });
+
+        var invocation = new Invocation
+        {
+            Capability = rootCapability.Id,
+            CapabilityAction = "read",
+            InvocationTarget = "https://example.com/resource"
+        };
+        invocation.Proof = await _signingService.SignInvocationAsync(invocation, controllerDid);
+
+        // Act
+        var result = await _verificationService.VerifyInvocationAsync(
+            invocation, rootCapability, new Dictionary<string, object>());
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
     #endregion
 
     #region Revocation Tests
@@ -898,4 +1031,21 @@ public class VerificationServiceTests
     }
 
     #endregion
+}
+
+/// <summary>
+/// Test caveat that reads "contentType" from InvocationContext.Properties.
+/// Used to verify that contextProperties flow through the verification pipeline.
+/// </summary>
+internal class ContentTypeCaveat : Caveat
+{
+    public override string Type => "ContentType";
+    public string RequiredContentType { get; set; } = string.Empty;
+
+    public override bool IsSatisfied(InvocationContext context)
+    {
+        return context.Properties.TryGetValue("contentType", out var value)
+            && value is string contentType
+            && string.Equals(contentType, RequiredContentType, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a 3-param `VerifyInvocationAsync(invocation, capability, contextProperties)` overload to `IVerificationService` and `VerificationService` that merges caller-provided `Dictionary<string, object>` into `InvocationContext.Properties` before caveat evaluation
- Existing 2-param overload delegates to the new method with `null`, ensuring full backward compatibility
- Adds 4 new tests (271 total) covering correct injection, wrong value rejection, null properties, and empty properties
- Adds Example 9 demonstrating the pattern with a `ContentTypeCaveat` that enforces `application/json`

Closes #15

## Test plan

- [x] `dotnet build ZcapLd.sln` — compiles clean (0 warnings, 0 errors)
- [x] `dotnet test ZcapLd.sln` — all 271 tests pass
- [x] `dotnet run --project examples/ZcapLd.Examples` — all 9 examples run correctly
- [x] Review that existing callers of `VerifyInvocationAsync(invocation, capability)` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)