### PR TITLE
Polymorphic Caveat serialization for cross-language interop (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Root capabilities and invocation proofs no longer emit empty/null optional fields on the wire (Issue #37). `allowedAction`, `caveat`, `parentCapability`, `expires`, `proof` (on root capabilities) and `capabilityChain` (on invocation proofs) are omitted when unset. Strict cross-language parsers (`zcap-py` and others) reject `"allowedAction": []` / `"capabilityChain": []` / `null` on optional fields when present, so emit-as-empty broke cross-stack interop. Companion to PR #34's flat-shape fix.
+- `Caveat[]` polymorphic serialization preserves derived-class fields across the signing boundary (Issue #39). Previously, STJ used the static array element type for `Capability.Caveat`, silently dropping derived fields like `Expires`, `Uri`, or third-party budget counters at sign time. Sign-time JCS now produces byte-identical bytes to whatever a cross-language verifier (`zcap-py` and friends) computes over the wire body re-emitted via the runtime concrete type.
+
+### Added
+
+- `CaveatTypeRegistry` (in `ZcapLd.Core.Models`) with a `Default` singleton pre-populated with the in-library caveat types. Third-party caveat libraries register their derived types via `CaveatTypeRegistry.Default.Register<T>(discriminator)` so the polymorphic JSON converter can dispatch deserialization across packages.
+- `ZcapJsonOptions.Default` (in `ZcapLd.Core.Cryptography`) — single source of truth for the `JsonSerializerOptions` shared by sign-time canonicalization and verifier-time chain deserialization (RFC 8785-compatible escaping, `WhenWritingNull`, the caveat converter).
+- `AddZcapCaveatType<TCaveat>(string discriminator)` ASP.NET DI extension on `IServiceCollection`, mirroring the `AddZcapCryptoSuite<T>()` shape.
+- `CaveatJsonConverter` — internal `JsonConverter<Caveat>` wired into `ZcapJsonOptions.Default`. `Write` dispatches to the runtime concrete type so derived fields are emitted; `Read` resolves the `type` discriminator against `CaveatTypeRegistry.Default` and deserializes via reflection, throwing `JsonException` with a registry-friendly hint when the discriminator is unknown.
 
 ### Changed
 
 - **BREAKING (wire format)**: `Capability.AllowedAction` and `Capability.Caveat` are now nullable (`string[]?` / `Caveat[]?`). Previously defaulted to `Array.Empty<>()`, producing `[]` on the wire. JCS canonical bytes change for any root capability, so signatures over the old shape no longer verify.
 - **BREAKING (wire format)**: `Proof.CapabilityChain` is now nullable (`object[]?`) and omitted on invocation proofs, which spec-correctly carry no chain.
+- **BREAKING (wire format)**: capabilities with non-empty caveats now sign over the full caveat shape (including derived-class fields), not the discriminator-only stub. Signatures over the old shape no longer verify.
+- **BREAKING (semantics)**: `UsageCountCaveat.CurrentUses` is now `[JsonIgnore]`. It's runtime state, not the signed policy — including it in the canonical bytes would invalidate the signature on every increment. Only `MaxUses` (the policy) is part of the wire body now.
 - All five optional `Capability` fields (`AllowedAction`, `Expires`, `ParentCapability`, `Caveat`, `Proof`), `Invocation.Proof`, and `Proof.CapabilityChain` carry `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`.
 - `CapabilityService.CreateRootCapabilityAsync` no longer assigns `Array.Empty<>()` / `null` to optional fields — they stay unset.
 - `CapabilityService.InheritCaveats` returns `Caveat[]?` and yields `null` when neither parent nor child supplies caveats, so delegations with no caveats also stay clean on the wire.
 - `SigningService.SignInvocationAsync` no longer sets `CapabilityChain = Array.Empty<object>()` on invocation proofs.
-- New `CrossLanguageJcsInteropTests` fixtures pin the new wire shape: root capability emits only `{@context, controller, id, invocationTarget}`, and invocation proofs no longer contain `"capabilityChain"`.
+- `ProofSigningPayloadBuilder.ModelSerializerOptions` now resolves to `ZcapJsonOptions.Default`; `VerificationService` chain deserialization uses the same options. Sign-time and verifier-time JSON paths share one configuration.
+- New `CrossLanguageJcsInteropTests` fixtures pin the new wire shape: root capability emits only `{@context, controller, id, invocationTarget}`; invocation proofs no longer contain `"capabilityChain"`; capabilities with `ExpirationCaveat` / `ValidWhileTrueCaveat` produce sign-time bytes byte-equal to whatever a cross-language verifier JCS-canonicalizes over the wire body.
 
 ## [1.2.0] - Released
 

--- a/examples/ZcapLd.Examples/Program.cs
+++ b/examples/ZcapLd.Examples/Program.cs
@@ -470,6 +470,12 @@ Console.WriteLine("---------------------------------------------------------");
 // The 3-param VerifyInvocationAsync overload lets callers inject these properties
 // into InvocationContext.Properties, where custom caveats can read them.
 
+// Register the custom caveat so the polymorphic JSON converter can round-trip
+// it across the signing boundary. In-memory pipelines work without this, but
+// any HTTP-transported wire body needs the registration before deserialization
+// can produce ContentTypeCaveat (vs. throwing on the abstract Caveat base).
+CaveatTypeRegistry.Default.Register<ContentTypeCaveat>("ContentType");
+
 var apiOwnerDid = "did:key:z6MkApiOwner";
 var clientDid = "did:key:z6MkClient";
 didProvider.GenerateAndRegisterKeyPair(apiOwnerDid);

--- a/src/ZcapLd.AspNetCore/DependencyInjection/ZcapRevocationServiceCollectionExtensions.cs
+++ b/src/ZcapLd.AspNetCore/DependencyInjection/ZcapRevocationServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ZcapLd.AspNetCore.Services;
 using ZcapLd.Core.Cryptography;
+using ZcapLd.Core.Models;
 using ZcapLd.Core.Services;
 
 namespace ZcapLd.AspNetCore.DependencyInjection;
@@ -101,6 +102,33 @@ public static class ZcapRevocationServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICryptoSuite, TSuite>());
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a derived <see cref="Caveat"/> type against its on-the-wire
+    /// `type` discriminator so the polymorphic JSON converter can serialize and
+    /// deserialize it across the signing boundary (Issue #39). Without this,
+    /// derived-class fields (e.g. <c>Expires</c>, <c>MaxUses</c>, custom budget
+    /// counters) are silently dropped at sign time.
+    ///
+    /// Mutates <see cref="CaveatTypeRegistry.Default"/> directly — registration
+    /// is process-global, mirroring how <see cref="AddZcapCryptoSuite{TSuite}"/>
+    /// composes additional suites onto a single provider.
+    ///
+    /// Call before <see cref="AddZcapServices"/> resolves the service provider,
+    /// or at any point before the first signing or verification call.
+    /// </summary>
+    public static IServiceCollection AddZcapCaveatType<TCaveat>(
+        this IServiceCollection services,
+        string discriminator)
+        where TCaveat : Caveat
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        if (string.IsNullOrEmpty(discriminator))
+            throw new ArgumentException("Discriminator cannot be null or empty", nameof(discriminator));
+
+        CaveatTypeRegistry.Default.Register<TCaveat>(discriminator);
         return services;
     }
 

--- a/src/ZcapLd.Core/Cryptography/CaveatJsonConverter.cs
+++ b/src/ZcapLd.Core/Cryptography/CaveatJsonConverter.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ZcapLd.Core.Models;
+
+namespace ZcapLd.Core.Cryptography;
+
+/// <summary>
+/// Polymorphic JSON converter for <see cref="Caveat"/> that dispatches by the
+/// `type` discriminator at read time and by the runtime CLR type at write time.
+///
+/// Without this converter, STJ uses the static array element type (<see cref="Caveat"/>,
+/// abstract) when serializing a <c>Caveat[]</c>, silently dropping derived-class
+/// fields (Issue #39). The result: sign-time JCS sees `[{"type":"Expiration"}]`
+/// while the wire body any orchestrator emits via <c>value.GetType()</c> carries
+/// the full `[{"type":"Expiration","expires":"..."}]`. zcap-py and other
+/// cross-language verifiers re-canonicalize the wire body, hashes diverge, and
+/// signature verification fails at the chain link with the caveat.
+///
+/// <see cref="CanConvert"/> matches only the abstract base type so concrete-type
+/// recursion bottoms out at default reflection — no infinite loop, derived
+/// classes serialize through normal STJ machinery.
+/// </summary>
+internal sealed class CaveatJsonConverter : JsonConverter<Caveat>
+{
+    private readonly CaveatTypeRegistry _registry;
+
+    public CaveatJsonConverter(CaveatTypeRegistry registry)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+    }
+
+    public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(Caveat);
+
+    public override Caveat? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        var root = document.RootElement;
+
+        if (root.ValueKind != JsonValueKind.Object)
+            throw new JsonException($"Expected JSON object for Caveat, got {root.ValueKind}.");
+
+        if (!root.TryGetProperty("type", out var typeProp) || typeProp.ValueKind != JsonValueKind.String)
+            throw new JsonException("Caveat JSON object is missing required 'type' discriminator.");
+
+        var discriminator = typeProp.GetString()!;
+        var concreteType = _registry.Resolve(discriminator)
+            ?? throw new JsonException(
+                $"No Caveat type registered for discriminator '{discriminator}'. " +
+                $"Register it via CaveatTypeRegistry.Default.Register<T>(\"{discriminator}\") " +
+                $"before signing or verifying capabilities that carry this caveat.");
+
+        return (Caveat?)JsonSerializer.Deserialize(root.GetRawText(), concreteType, options);
+    }
+
+    public override void Write(Utf8JsonWriter writer, Caveat value, JsonSerializerOptions options)
+    {
+        // Dispatch to the runtime concrete type so STJ writes derived fields.
+        // CanConvert returns false for concrete types, so this recursion bottoms
+        // out at default reflection serialization.
+        JsonSerializer.Serialize(writer, value, value.GetType(), options);
+    }
+}

--- a/src/ZcapLd.Core/Cryptography/ProofSigningPayloadBuilder.cs
+++ b/src/ZcapLd.Core/Cryptography/ProofSigningPayloadBuilder.cs
@@ -25,19 +25,11 @@ internal static class ProofSigningPayloadBuilder
     private static readonly JcsDocumentCanonicalizer DefaultJcs = new();
 
     /// <summary>
-    /// Round-trips Capability / Proof / Invocation through System.Text.Json so that
-    /// model properties contribute only the field names and value shapes their
-    /// [JsonPropertyName] / [JsonIgnore(WhenWritingNull)] / [JsonConverter] attributes
-    /// dictate. The result matches the on-the-wire JSON byte-for-byte (after JCS
-    /// alphabetic sort), which is what every other Data Integrity verifier sees.
+    /// Sign-time and verifier-time JSON options live in <see cref="ZcapJsonOptions.Default"/>
+    /// so the <see cref="CaveatJsonConverter"/> registration is shared. Without this,
+    /// sign-time and wire-emit serializers diverge for any non-trivial caveat (Issue #39).
     /// </summary>
-    private static readonly JsonSerializerOptions ModelSerializerOptions = new()
-    {
-        WriteIndented = false,
-        PropertyNamingPolicy = null,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-    };
+    private static JsonSerializerOptions ModelSerializerOptions => ZcapJsonOptions.Default;
 
     public static Capability CloneCapabilityWithoutProof(Capability capability)
     {

--- a/src/ZcapLd.Core/Cryptography/ZcapJsonOptions.cs
+++ b/src/ZcapLd.Core/Cryptography/ZcapJsonOptions.cs
@@ -18,9 +18,10 @@ namespace ZcapLd.Core.Cryptography;
 /// - <c>DefaultIgnoreCondition = WhenWritingNull</c>: drops absent optional
 ///   fields so strict cross-language parsers (zcap-py and friends) accept the
 ///   wire body. See #37.
-/// - <c>UnsafeRelaxedJsonEscaping</c>: RFC 8785 §3.2.2.2 mandates only `"`,
-///   `\`, and control characters be escaped. The default <c>JavaScriptEncoder</c>
-///   escapes `+`, `<`, `>`, `&` to `\u00xx`, which diverges from peer
+    /// - <c>UnsafeRelaxedJsonEscaping</c>: RFC 8785 §3.2.2.2 mandates only
+    ///   quotation marks, backslashes, and control characters be escaped. The
+    ///   default <c>JavaScriptEncoder</c> escapes plus signs, angle brackets,
+    ///   ampersands, and apostrophes to Unicode escape sequences, which diverges from peer
 ///   canonicalizers. See #36.
 /// - <see cref="CaveatJsonConverter"/>: makes <see cref="Caveat"/> arrays
 ///   round-trip through their derived classes' fields. See #39.

--- a/src/ZcapLd.Core/Cryptography/ZcapJsonOptions.cs
+++ b/src/ZcapLd.Core/Cryptography/ZcapJsonOptions.cs
@@ -1,0 +1,50 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ZcapLd.Core.Models;
+
+namespace ZcapLd.Core.Cryptography;
+
+/// <summary>
+/// Single source of truth for the <see cref="JsonSerializerOptions"/> that
+/// governs both sign-time JCS canonicalization and verifier-time chain
+/// deserialization. Sharing one options instance means the bytes signed equal
+/// the bytes seen by any other Data Integrity verifier that re-canonicalizes
+/// the wire body — that is the contract Issues #34, #37, and #39 collectively
+/// pin down.
+///
+/// Settings rationale:
+/// - <c>WriteIndented = false</c>: JCS is whitespace-free.
+/// - <c>DefaultIgnoreCondition = WhenWritingNull</c>: drops absent optional
+///   fields so strict cross-language parsers (zcap-py and friends) accept the
+///   wire body. See #37.
+/// - <c>UnsafeRelaxedJsonEscaping</c>: RFC 8785 §3.2.2.2 mandates only `"`,
+///   `\`, and control characters be escaped. The default <c>JavaScriptEncoder</c>
+///   escapes `+`, `<`, `>`, `&` to `\u00xx`, which diverges from peer
+///   canonicalizers. See #36.
+/// - <see cref="CaveatJsonConverter"/>: makes <see cref="Caveat"/> arrays
+///   round-trip through their derived classes' fields. See #39.
+/// </summary>
+public static class ZcapJsonOptions
+{
+    /// <summary>
+    /// Pre-configured options used everywhere capabilities, invocations, or
+    /// proofs cross the signing boundary. The caveat converter resolves
+    /// against <see cref="CaveatTypeRegistry.Default"/>, so consumers can
+    /// register custom caveat types at startup without rebuilding options.
+    /// </summary>
+    public static JsonSerializerOptions Default { get; } = CreateDefault();
+
+    private static JsonSerializerOptions CreateDefault()
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            PropertyNamingPolicy = null,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+        options.Converters.Add(new CaveatJsonConverter(CaveatTypeRegistry.Default));
+        return options;
+    }
+}

--- a/src/ZcapLd.Core/Models/Caveat.cs
+++ b/src/ZcapLd.Core/Models/Caveat.cs
@@ -54,9 +54,12 @@ public class UsageCountCaveat : Caveat
     public int MaxUses { get; set; }
 
     /// <summary>
-    /// Current usage count
+    /// Current usage count. Runtime state — NOT serialized because it changes
+    /// over the capability's lifetime; the signed policy is <see cref="MaxUses"/>.
+    /// Including this in the signed JCS payload would invalidate the signature
+    /// on every increment, which is incompatible with how usage tracking works.
     /// </summary>
-    [JsonPropertyName("currentUses")]
+    [JsonIgnore]
     public int CurrentUses { get; set; }
 
     public override bool IsSatisfied(InvocationContext context)

--- a/src/ZcapLd.Core/Models/CaveatTypeRegistry.cs
+++ b/src/ZcapLd.Core/Models/CaveatTypeRegistry.cs
@@ -1,0 +1,64 @@
+using System.Collections.Concurrent;
+
+namespace ZcapLd.Core.Models;
+
+/// <summary>
+/// Maps `Caveat.Type` discriminator strings to concrete CLR types so the
+/// <see cref="ZcapLd.Core.Cryptography.CaveatJsonConverter"/> can dispatch
+/// polymorphic deserialization across packages — third-party caveat libraries
+/// register their derived types here at startup, the same way custom crypto
+/// suites register through <c>ICryptoSuiteProvider</c>.
+///
+/// The <see cref="Default"/> singleton is pre-populated with the in-library
+/// caveats. The converter holds a reference to <see cref="Default"/> and
+/// resolves dynamically, so registrations performed any time before the first
+/// signing or verification call take effect.
+/// </summary>
+public sealed class CaveatTypeRegistry
+{
+    private readonly ConcurrentDictionary<string, Type> _byDiscriminator =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Process-wide singleton consulted by the default JSON converter.
+    /// In-library types are registered in the static constructor.
+    /// </summary>
+    public static CaveatTypeRegistry Default { get; } = CreateDefault();
+
+    private static CaveatTypeRegistry CreateDefault()
+    {
+        var registry = new CaveatTypeRegistry();
+        registry.Register<ExpirationCaveat>("Expiration");
+        registry.Register<UsageCountCaveat>("UsageCount");
+        registry.Register<ValidWhileTrueCaveat>("ValidWhileTrue");
+        return registry;
+    }
+
+    /// <summary>
+    /// Registers a derived caveat type against its on-the-wire discriminator.
+    /// Idempotent for the same (discriminator, type) pair; throws on conflict.
+    /// </summary>
+    public void Register<TCaveat>(string discriminator) where TCaveat : Caveat
+    {
+        if (string.IsNullOrEmpty(discriminator))
+            throw new ArgumentException("Discriminator cannot be null or empty", nameof(discriminator));
+
+        var existing = _byDiscriminator.GetOrAdd(discriminator, typeof(TCaveat));
+        if (existing != typeof(TCaveat))
+        {
+            throw new InvalidOperationException(
+                $"Discriminator '{discriminator}' is already registered to {existing.FullName}; " +
+                $"cannot re-register to {typeof(TCaveat).FullName}.");
+        }
+    }
+
+    /// <summary>
+    /// Looks up a registered caveat type by discriminator. Returns null when
+    /// no type is registered — callers throw the localized error.
+    /// </summary>
+    public Type? Resolve(string discriminator)
+    {
+        ArgumentNullException.ThrowIfNull(discriminator);
+        return _byDiscriminator.TryGetValue(discriminator, out var type) ? type : null;
+    }
+}

--- a/src/ZcapLd.Core/Services/VerificationService.cs
+++ b/src/ZcapLd.Core/Services/VerificationService.cs
@@ -617,7 +617,11 @@ public class VerificationService : IVerificationService
 
         if (element is JsonElement jsonElement && jsonElement.ValueKind == JsonValueKind.Object)
         {
-            capability = JsonSerializer.Deserialize<Capability>(jsonElement.GetRawText());
+            // Use shared options so caveats round-trip through their derived-class
+            // fields — without this, embedded chain capabilities carrying caveats
+            // either deserialize as discriminator-only stubs or throw on the
+            // abstract Caveat base type (Issue #39).
+            capability = JsonSerializer.Deserialize<Capability>(jsonElement.GetRawText(), ZcapJsonOptions.Default);
             return capability != null;
         }
 

--- a/tasks/todo20260501232810.md
+++ b/tasks/todo20260501232810.md
@@ -1,0 +1,20 @@
+# Issue #39 Addressed Check
+
+- [x] Fetch issue #39 requirements
+- [x] Inspect caveat model polymorphic serialization
+- [x] Inspect sign-time JCS/wire serialization path
+- [x] Inspect regression tests for derived caveat fields and duplicate type fields
+- [x] Run focused and full validation tests
+- [x] Record review conclusion
+
+## Review
+
+Issue #39 is addressed. The polymorphic `Caveat` serialization gap in `Capability.Caveat` (and anywhere a `Caveat[]` was being serialized through STJ's static-type dispatch) is now closed by a `CaveatTypeRegistry.Default` + custom `JsonConverter<Caveat>` wired into a shared `ZcapJsonOptions.Default`.
+
+Sign-time and wire-time serializers now share one `JsonSerializerOptions` instance (`ZcapJsonOptions.Default`); cross-language verifiers that JCS-canonicalize the wire body see byte-identical bytes to what was signed. New cross-language fixture `CapabilityWithDerivedCaveat_SignTimeAndWireBytes_AreByteEqual` is the load-bearing regression guard for the cross-stack failure mode.
+
+Adjacent semantic fix: `UsageCountCaveat.CurrentUses` is now `[JsonIgnore]` — runtime state was leaking into signed bytes, invalidating the signature on every increment.
+
+`dotnet build ZcapLd.sln` clean. `dotnet test ZcapLd.sln` 305/305 (was 295; +10 new). All 10 console examples run end-to-end. Example 9 now demonstrates third-party caveat registration via `CaveatTypeRegistry.Default.Register<ContentTypeCaveat>("ContentType")` for HTTP-transported wire bodies.
+
+PR: https://github.com/moisesja/zcap-dotnet/pull/41

--- a/tests/ZcapLd.Core.Tests/Compliance/CrossLanguageJcsInteropTests.cs
+++ b/tests/ZcapLd.Core.Tests/Compliance/CrossLanguageJcsInteropTests.cs
@@ -76,6 +76,77 @@ public class CrossLanguageJcsInteropTests
         canonical.Should().NotContain("\"proofValue\"", "proofValue must never appear in the signing payload");
     }
 
+    [Fact(DisplayName = "Issue #39 — sign-time and wire-time bytes match for capability with derived caveats")]
+    public void CapabilityWithDerivedCaveat_SignTimeAndWireBytes_AreByteEqual()
+    {
+        // The cross-stack failure mode: zcap-dotnet signs JCS over a payload where
+        // Caveat[] elements drop their derived fields (sign-time sees `{"type":"Expiration"}`).
+        // The orchestrator emits the wire body via the runtime concrete type, so zcap-py sees
+        // `{"type":"Expiration","expires":"..."}` and re-canonicalizes — different bytes,
+        // signature verification fails. After the converter ships, both paths produce the
+        // same bytes for any registered caveat type.
+        var capability = new Capability
+        {
+            Id = "urn:uuid:fixed-delegated-with-caveat",
+            Context = "https://w3id.org/zcap/v1",
+            Controller = "did:key:z6MkfixedController",
+            InvocationTarget = "https://example.com/api/resource",
+            AllowedAction = new[] { "read" },
+            Expires = "2027-01-01T00:00:00.000000Z",
+            ParentCapability = "urn:zcap:root:fixed",
+            Caveat = new Caveat[]
+            {
+                new ExpirationCaveat { Expires = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
+                new ValidWhileTrueCaveat { Uri = "https://revocation.example.com/abc" }
+            },
+            Proof = null
+        };
+        var proof = new Proof
+        {
+            Type = "Ed25519Signature2020",
+            Created = "2026-04-29T12:00:00.000000Z",
+            ProofPurpose = "capabilityDelegation",
+            VerificationMethod = "did:key:z6MkfixedSigner#z6MkfixedSigner",
+            CapabilityChain = new object[] { "urn:zcap:root:fixed" },
+            ProofValue = "this-must-be-excluded"
+        };
+
+        // Sign-time path — what gets hashed and signed.
+        var signTimeBytes = ProofSigningPayloadBuilder.CanonicalizeCapabilityPayload(capability, proof);
+        var signTimeJson = Encoding.UTF8.GetString(signTimeBytes);
+
+        // Both derived-class fields must be in the signed bytes — that's the regression
+        // guard for #39. STJ's default DateTime serialization for DateTimeKind.Utc emits
+        // an ISO-8601 string with `Z` suffix; we just check for the date component.
+        signTimeJson.Should().Contain("\"type\":\"Expiration\"");
+        signTimeJson.Should().Contain("2027-01-01",
+            "ExpirationCaveat.Expires is part of the signed wire bytes (#39)");
+        signTimeJson.Should().Contain("\"type\":\"ValidWhileTrue\"");
+        signTimeJson.Should().Contain("\"uri\":\"https://revocation.example.com/abc\"",
+            "ValidWhileTrueCaveat.Uri is part of the signed wire bytes (#39)");
+
+        // Wire-time path — what zcap-py would JCS-canonicalize over the same wire body.
+        // Build the JCS payload by hand using the shared options + flat W3C shape, the
+        // same way ProofSigningPayloadBuilder does internally.
+        var canonicalizer = new JcsDocumentCanonicalizer();
+        var wireDoc = new Dictionary<string, object>(StringComparer.Ordinal);
+        var capElement = JsonSerializer.SerializeToElement(capability, ZcapJsonOptions.Default);
+        foreach (var prop in capElement.EnumerateObject())
+            wireDoc[prop.Name] = prop.Value;
+        var proofElement = JsonSerializer.SerializeToElement(proof, ZcapJsonOptions.Default);
+        var proofDict = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach (var prop in proofElement.EnumerateObject())
+            if (prop.Name != "proofValue") proofDict[prop.Name] = prop.Value;
+        wireDoc["proof"] = proofDict;
+        var wireBytes = canonicalizer.Canonicalize(wireDoc);
+
+        // Load-bearing assertion: signed bytes == bytes any other Data Integrity verifier sees.
+        wireBytes.Should().Equal(signTimeBytes,
+            "the bytes signed by zcap-dotnet must equal the bytes zcap-py JCS-canonicalizes " +
+            "over the wire body — otherwise signature verification fails at the chain link " +
+            "with the caveat (#39).");
+    }
+
     [Fact(DisplayName = "Issue #37 — root capability wire form omits absent optional fields")]
     public void RootCapabilityWireForm_OmitsAbsentOptionalFields()
     {

--- a/tests/ZcapLd.Core.Tests/Cryptography/CaveatJsonConverterTests.cs
+++ b/tests/ZcapLd.Core.Tests/Cryptography/CaveatJsonConverterTests.cs
@@ -1,0 +1,172 @@
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+using ZcapLd.Core.Cryptography;
+using ZcapLd.Core.Models;
+
+namespace ZcapLd.Core.Tests.Cryptography;
+
+/// <summary>
+/// Issue #39 — verify the polymorphic Caveat converter preserves derived-class
+/// fields through both the sign-time and verifier-time JSON paths. Without this
+/// converter, STJ uses the static array element type when serializing
+/// <c>Caveat[]</c>, silently dropping derived fields and making cross-language
+/// signature verification fail at the chain link with the caveat.
+/// </summary>
+public class CaveatJsonConverterTests
+{
+    [Fact(DisplayName = "Issue #39 — single Caveat serializes with derived fields")]
+    public void Serialize_DerivedCaveat_PreservesDerivedFields()
+    {
+        Caveat caveat = new ExpirationCaveat
+        {
+            Expires = new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc)
+        };
+
+        var json = JsonSerializer.Serialize(caveat, ZcapJsonOptions.Default);
+
+        json.Should().Contain("\"type\":\"Expiration\"");
+        json.Should().Contain("\"expires\":");
+        // Without the converter, STJ would write only `{"type":"Expiration"}`.
+    }
+
+    [Fact(DisplayName = "Issue #39 — Caveat[] serializes each element with its derived fields")]
+    public void Serialize_AsArray_PreservesDerivedFields()
+    {
+        var caveats = new Caveat[]
+        {
+            new ExpirationCaveat { Expires = new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc) },
+            new UsageCountCaveat { MaxUses = 5 },
+            new ValidWhileTrueCaveat { Uri = "https://revocation.example.com/check/abc" }
+        };
+
+        var json = JsonSerializer.Serialize(caveats, ZcapJsonOptions.Default);
+
+        json.Should().Contain("\"type\":\"Expiration\"");
+        json.Should().Contain("\"expires\":");
+        json.Should().Contain("\"type\":\"UsageCount\"");
+        json.Should().Contain("\"maxUses\":5");
+        json.Should().Contain("\"type\":\"ValidWhileTrue\"");
+        json.Should().Contain("\"uri\":\"https://revocation.example.com/check/abc\"");
+    }
+
+    [Fact(DisplayName = "Issue #39 — UsageCountCaveat.CurrentUses is runtime state and stays out of the wire")]
+    public void Serialize_UsageCount_OmitsCurrentUses()
+    {
+        Caveat caveat = new UsageCountCaveat { MaxUses = 10, CurrentUses = 7 };
+
+        var json = JsonSerializer.Serialize(caveat, ZcapJsonOptions.Default);
+
+        json.Should().Contain("\"maxUses\":10");
+        // CurrentUses changes over the capability's lifetime; including it in
+        // signed bytes would invalidate the signature on every increment.
+        json.Should().NotContain("currentUses");
+    }
+
+    [Fact(DisplayName = "Deserialize known discriminator round-trips to concrete type with all fields")]
+    public void Deserialize_KnownDiscriminator_ProducesConcreteType()
+    {
+        var json = "{\"type\":\"Expiration\",\"expires\":\"2026-12-31T23:59:59Z\"}";
+
+        var caveat = JsonSerializer.Deserialize<Caveat>(json, ZcapJsonOptions.Default);
+
+        caveat.Should().BeOfType<ExpirationCaveat>();
+        caveat!.Type.Should().Be("Expiration");
+        ((ExpirationCaveat)caveat).Expires.Should().Be(
+            new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc));
+    }
+
+    [Fact(DisplayName = "Deserialize unknown discriminator throws JsonException with a registry-friendly hint")]
+    public void Deserialize_UnknownDiscriminator_Throws()
+    {
+        var json = "{\"type\":\"NotARealCaveatType\",\"foo\":42}";
+
+        var act = () => JsonSerializer.Deserialize<Caveat>(json, ZcapJsonOptions.Default);
+
+        act.Should().Throw<JsonException>()
+            .WithMessage("*NotARealCaveatType*")
+            .WithMessage("*CaveatTypeRegistry*");
+    }
+
+    [Fact(DisplayName = "Deserialize without 'type' discriminator throws")]
+    public void Deserialize_MissingDiscriminator_Throws()
+    {
+        var json = "{\"expires\":\"2026-12-31T23:59:59Z\"}";
+
+        var act = () => JsonSerializer.Deserialize<Caveat>(json, ZcapJsonOptions.Default);
+
+        act.Should().Throw<JsonException>().WithMessage("*type*");
+    }
+
+    [Fact(DisplayName = "Round-trip: serialize then deserialize preserves derived-class state")]
+    public void RoundTrip_PreservesDerivedFields()
+    {
+        Caveat[] original =
+        {
+            new ExpirationCaveat { Expires = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc) },
+            new UsageCountCaveat { MaxUses = 3 },
+            new ValidWhileTrueCaveat { Uri = "https://revocation.example.com/x" }
+        };
+
+        var json = JsonSerializer.Serialize(original, ZcapJsonOptions.Default);
+        var deserialized = JsonSerializer.Deserialize<Caveat[]>(json, ZcapJsonOptions.Default);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.Should().HaveCount(3);
+
+        deserialized[0].Should().BeOfType<ExpirationCaveat>()
+            .Which.Expires.Should().Be(new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc));
+        deserialized[1].Should().BeOfType<UsageCountCaveat>()
+            .Which.MaxUses.Should().Be(3);
+        deserialized[2].Should().BeOfType<ValidWhileTrueCaveat>()
+            .Which.Uri.Should().Be("https://revocation.example.com/x");
+    }
+
+    [Fact(DisplayName = "Custom caveat registered against Default registry round-trips through the converter")]
+    public void RegisterCustomCaveat_RoundTrips()
+    {
+        // Use a discriminator unique to this test so re-runs in the same process
+        // (xUnit doesn't tear down AppDomain) don't trip the conflict guard.
+        var discriminator = $"TestCaveat-{Guid.NewGuid():N}";
+        CaveatTypeRegistry.Default.Register<TestCustomCaveat>(discriminator);
+
+        Caveat caveat = new TestCustomCaveat(discriminator) { Threshold = 42 };
+        var json = JsonSerializer.Serialize(caveat, ZcapJsonOptions.Default);
+        var roundTripped = JsonSerializer.Deserialize<Caveat>(json, ZcapJsonOptions.Default);
+
+        roundTripped.Should().BeOfType<TestCustomCaveat>()
+            .Which.Threshold.Should().Be(42);
+    }
+
+    [Fact(DisplayName = "Re-registering same discriminator with a different type throws")]
+    public void Register_ConflictingType_Throws()
+    {
+        var discriminator = $"ConflictCaveat-{Guid.NewGuid():N}";
+        CaveatTypeRegistry.Default.Register<TestCustomCaveat>(discriminator);
+
+        var act = () => CaveatTypeRegistry.Default.Register<AnotherTestCaveat>(discriminator);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*'{discriminator}'*already registered*");
+    }
+
+    private sealed class TestCustomCaveat : Caveat
+    {
+        private readonly string _type;
+        public TestCustomCaveat() : this("TestCaveat") { }
+        public TestCustomCaveat(string type) { _type = type; }
+
+        public override string Type => _type;
+
+        [System.Text.Json.Serialization.JsonPropertyName("threshold")]
+        public int Threshold { get; set; }
+
+        public override bool IsSatisfied(InvocationContext context) => true;
+    }
+
+    private sealed class AnotherTestCaveat : Caveat
+    {
+        public override string Type => "Another";
+        public override bool IsSatisfied(InvocationContext context) => true;
+    }
+}


### PR DESCRIPTION
Closes #39.

## Summary

- Sibling fix to #34 (JCS wrapper) and #37 (root-cap empty/null fields) — same bug class, third occurrence: zcap-dotnet's sign-time JCS payload diverged from the wire body (this time on `Caveat[]` polymorphism), so cross-language verifiers re-canonicalized the wire body and signature verification failed at the chain link with the caveat. End-to-end run in `privacy-clinical-ai-framework` was hitting `SignatureVerificationError: Ed25519 signature verification failed` because zcap-py saw `[{"type":"Expiration","expires":"..."}]` while the signed payload only had `[{"type":"Expiration"}]`.
- New `CaveatTypeRegistry.Default` (process-wide singleton) + custom `JsonConverter<Caveat>` that reads by `type` discriminator and writes via `value.GetType()`, so derived-class fields land on the wire. In-library types (`ExpirationCaveat`, `UsageCountCaveat`, `ValidWhileTrueCaveat`) pre-registered. Third-party caveat libraries register their derived types via `CaveatTypeRegistry.Default.Register<T>(s)` or the new `AddZcapCaveatType<T>(s)` ASP.NET DI extension.
- New shared `ZcapJsonOptions.Default` is now the single source of truth for `JsonSerializerOptions` across sign-time canonicalization and verifier-time chain deserialization. Previously `VerificationService.TryDeserializeCapability` used default STJ options with no converter — a parallel silent-bug surface where chain capabilities carrying caveats either threw on the abstract base or deserialized as discriminator-only stubs. Now both paths share one config.

## Semantic fix riding along

- `UsageCountCaveat.CurrentUses` is now `[JsonIgnore]`. It's runtime state, not the signed policy — including it in canonical bytes invalidates the signature on every increment. Only `MaxUses` (the policy) is part of the wire body. The existing `CompleteWorkflow_WithUsageCountCaveat_ShouldEnforce` integration test was passing only because the caveat polymorphism bug silently dropped the field; once derived fields emit correctly, in-place mutation after signing has to be off the wire.

## Architectural notes

- `[JsonDerivedType]` on the abstract base would have forced Core to know every derived type at compile time — unworkable for third-party caveats. The registry+converter pattern composes across packages.
- Static `Default` singleton (vs. DI-only registry): the codebase has both DI consumers (ASP.NET) and direct-construction consumers (the console examples). DI-only would have broken the example; the static `Default` lets `AddZcapCaveatType<T>()` be sugar over `Default.Register<T>()`.
- **BREAKING (wire format)**: capabilities with non-empty caveats now sign over the full caveat shape. Folded into the unreleased v3.0.0 alongside #36 and #37 — no back-compat shim per maintainer direction.

## Test plan

- [x] `dotnet build ZcapLd.sln` — clean, 0 errors
- [x] `dotnet test ZcapLd.sln` — 305/305 (was 295, +10 new: 9 converter tests + 1 cross-language byte-equality fixture)
- [x] `dotnet run --project examples/ZcapLd.Examples` — all 10 examples run end-to-end clean. Example 9 now demonstrates third-party caveat registration via `CaveatTypeRegistry.Default.Register<ContentTypeCaveat>("ContentType")` (required for HTTP-transported wire bodies; in-memory chains worked without it, masking the requirement).
- [x] **Load-bearing regression guard**: `CapabilityWithDerivedCaveat_SignTimeAndWireBytes_AreByteEqual` builds a delegated capability with `ExpirationCaveat` + `ValidWhileTrueCaveat`, runs both the `ProofSigningPayloadBuilder` path and a hand-rolled wire-time JCS path through `ZcapJsonOptions.Default`, and asserts byte equality. That's exactly the cross-stack failure mode in the issue.
- [ ] Cross-stack regression (post-merge): confirm zcap-py verifies a zcap-dotnet-signed capability with a derived caveat without any wire-shape massaging. Should let `privacy-clinical-ai-framework` drop the dual-mode proof verifier kludge on `37-temp-mitigation-zcap-dotnet-wire-format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)