### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [3.0.0] - Unreleased
+## [2.1.0] - Unreleased
 
 ### Fixed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <!-- Shared package/library version for ZcapLd.Core and ZcapLd.AspNetCore -->
-    <ZcapLdVersion>3.0.0</ZcapLdVersion>
+    <ZcapLdVersion>2.1.0</ZcapLdVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Sets `ZcapLdVersion` in [Directory.Build.props](Directory.Build.props) to `2.1.0` (was `3.0.0`). Both `ZcapLd.Core` and `ZcapLd.AspNetCore` reference `\$(ZcapLdVersion)` in their .csproj files, so a single edit covers both packages.

CHANGELOG.md heading flipped from `[3.0.0]` to `[2.1.0]` to match.

## Why 2.1.0

Last published tag was `core-v2.0.0`. The maintainer's call: 2.1.0 (minor) aligns with the additive-feature framing of #36/#37/#39 even though JCS canonical bytes change for any signed payload that previously carried empty/null optionals or polymorphic caveat data.

## Test plan

- [x] `dotnet build ZcapLd.sln` clean.
- [ ] After merge: tag `core-v2.1.0` and `aspnetcore-v2.1.0` and push to origin (commands in the chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)