### PR TITLE
Re-apply [JsonPropertyName("type")] on Caveat overrides (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.1.1] - Unreleased
+
+### Fixed
+
+- Concrete `Caveat` subclasses no longer emit duplicate `"Type"` / `"type"` keys on the wire (Issue #45). STJ on .NET 10 doesn't auto-inherit `[JsonPropertyName("type")]` from the abstract base override declaration; without an explicit attribute on the override, the runtime catalogues the override as a separate `JsonPropertyInfo` and emits the CLR name `"Type"` alongside the inherited `"type"`. Both keys landed on the wire, JCS preserved them both, and signature verification failed against any other Data Integrity implementation. Fix: re-apply `[JsonPropertyName("type")]` on `ExpirationCaveat`, `UsageCountCaveat`, and `ValidWhileTrueCaveat` overrides. Fourth and final layer of the cross-stack canonicalization contract from #34 / #36 / #37 / #39.
+
 ## [2.1.0] - Released
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <!-- Shared package/library version for ZcapLd.Core and ZcapLd.AspNetCore -->
-    <ZcapLdVersion>2.1.0</ZcapLdVersion>
+    <ZcapLdVersion>2.1.1</ZcapLdVersion>
   </PropertyGroup>
 </Project>

--- a/src/ZcapLd.Core/Models/Caveat.cs
+++ b/src/ZcapLd.Core/Models/Caveat.cs
@@ -26,6 +26,12 @@ public abstract class Caveat
 /// </summary>
 public class ExpirationCaveat : Caveat
 {
+    // STJ on .NET 10 doesn't auto-inherit [JsonPropertyName] from the abstract
+    // base override declaration — without an explicit attribute on the override,
+    // the runtime catalogues the override as a separate property and emits the
+    // CLR name `"Type"` alongside the inherited `"type"`. Two keys on the wire
+    // diverge from every other Data Integrity implementation. See #45.
+    [JsonPropertyName("type")]
     public override string Type => "Expiration";
 
     /// <summary>
@@ -45,6 +51,7 @@ public class ExpirationCaveat : Caveat
 /// </summary>
 public class UsageCountCaveat : Caveat
 {
+    [JsonPropertyName("type")]
     public override string Type => "UsageCount";
 
     /// <summary>

--- a/src/ZcapLd.Core/Models/ValidWhileTrueCaveat.cs
+++ b/src/ZcapLd.Core/Models/ValidWhileTrueCaveat.cs
@@ -13,6 +13,10 @@ namespace ZcapLd.Core.Models;
 /// </summary>
 public class ValidWhileTrueCaveat : Caveat
 {
+    // [JsonPropertyName] explicitly re-declared on the override — STJ on .NET 10
+    // doesn't auto-inherit from the abstract base, so without this the wire body
+    // carries duplicate `Type`/`type` keys. See #45.
+    [JsonPropertyName("type")]
     public override string Type => "ValidWhileTrue";
 
     /// <summary>

--- a/tests/ZcapLd.Core.Tests/Cryptography/CaveatJsonConverterTests.cs
+++ b/tests/ZcapLd.Core.Tests/Cryptography/CaveatJsonConverterTests.cs
@@ -98,6 +98,29 @@ public class CaveatJsonConverterTests
         act.Should().Throw<JsonException>().WithMessage("*type*");
     }
 
+    [Theory(DisplayName = "Issue #45 — concrete Caveat round-trip preserves wire bytes (no duplicate Type/type keys)")]
+    [InlineData(typeof(ExpirationCaveat), "{\"type\":\"Expiration\",\"expires\":\"2027-01-01T00:00:00Z\"}")]
+    [InlineData(typeof(UsageCountCaveat), "{\"type\":\"UsageCount\",\"maxUses\":5}")]
+    [InlineData(typeof(ValidWhileTrueCaveat), "{\"type\":\"ValidWhileTrue\",\"uri\":\"https://example.com/status\"}")]
+    public void Caveat_Roundtrip_PreservesWireBytes(Type concreteType, string wireJson)
+    {
+        // Without [JsonPropertyName("type")] on the concrete override, STJ on .NET 10
+        // catalogues the override as a separate property and emits the CLR name
+        // ("Type") alongside the inherited ("type"). Both keys land on the wire,
+        // JCS doesn't dedupe, and signature verification fails against any other
+        // Data Integrity implementation. The fix is per-subclass attribute
+        // re-declaration; this test guards against regression.
+        var deserialized = JsonSerializer.Deserialize(wireJson, concreteType, ZcapJsonOptions.Default)!;
+        var roundTripped = JsonSerializer.Serialize(deserialized, concreteType, ZcapJsonOptions.Default);
+
+        roundTripped.Should().Be(wireJson,
+            "wire bytes from a one-key body must round-trip byte-for-byte; duplicate " +
+            "\"Type\"/\"type\" keys break cross-stack signature verification (#45).");
+        roundTripped.Should().NotContain("\"Type\":",
+            "uppercase \"Type\" key indicates STJ catalogued the abstract-base property and " +
+            "the override as separate JsonPropertyInfo entries (#45 root cause).");
+    }
+
     [Fact(DisplayName = "Round-trip: serialize then deserialize preserves derived-class state")]
     public void RoundTrip_PreservesDerivedFields()
     {


### PR DESCRIPTION
Closes #45.

## Summary

Concrete `Caveat` subclasses (`ExpirationCaveat`, `UsageCountCaveat`, `ValidWhileTrueCaveat`) emit duplicate `"Type"` / `"type"` keys on the wire. STJ on .NET 10 doesn't auto-inherit `[JsonPropertyName]` from an abstract base override declaration — the runtime catalogues the override as a separate `JsonPropertyInfo` whose JSON name defaults to the CLR name (`"Type"`), while the base entry still emits `"type"`. Both fire on serialize.

Round-trip evidence on `main @ core-v2.1.0`:
```
in:  {"type":"UsageCount","maxUses":5}
out: {"Type":"UsageCount","maxUses":5,"type":"UsageCount"}
```

A verifier hashing the wire body computes different bytes from the bytes zcap-dotnet hashed at sign time. Cross-stack signature verification (zcap-py and others) fails on any capability with a non-empty caveat array. Surfaced by [zcap-interop-fixtures #1](https://github.com/moisesja/zcap-interop-fixtures/issues/1) running the matrix against `a3e8acc`.

This was the last leak through the cross-stack canonicalization contract from #34 / #36 / #37 / #39 — masked until #39 made polymorphic caveat deserialization actually reach the canonicalization stage.

Fix is mechanical: re-declare `[JsonPropertyName("type")]` on each concrete override. STJ collapses the two `JsonPropertyInfo` entries into one mapped to `"type"`. Abstract-base attribute stays as a guardrail for future overrides.

## Test plan

- [x] New Theory in [CaveatJsonConverterTests.cs](tests/ZcapLd.Core.Tests/Cryptography/CaveatJsonConverterTests.cs) — pins byte-for-byte round-trip for the three concrete subclasses; asserts `NotContain("\"Type\":")` to lock the regression surface. Today on `main` without the fix this test fails for all three; with the fix it passes.
- [x] `dotnet build ZcapLd.sln` clean.
- [x] `dotnet test ZcapLd.sln` — 308/308 (was 305; +3 Theory cases).
- [x] `dotnet run --project examples/ZcapLd.Examples` — all 10 examples green end-to-end.
- [ ] Cross-stack regression (post-merge): re-run the `zcap-interop-fixtures` matrix and confirm `capability-wrapper-vs-flat-isolation` and `capability-proof-field-whitelist` report PARITY against the .NET adapter — completes the four-fixture release-blocker contract.

## Version

Bumped `ZcapLdVersion` to **2.1.1** (patch). `core-v2.1.0` and `aspnetcore-v2.1.0` already shipped. Practically a no-op for cross-language deployments (the duplicate-key shape was never cross-language-verifiable anyway), so patch fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)