### PR TITLE
fix(#61): address PR #81 review — revoker auth semantics + SHOULD-04 assertion

### DIFF
--- a/src/ZcapLd.Core/Services/VerificationService.cs
+++ b/src/ZcapLd.Core/Services/VerificationService.cs
@@ -726,6 +726,14 @@ public class VerificationService : IVerificationService
         try
         {
             var chain = await BuildCapabilityChainAsync(capability);
+            // Authorization is a string-level controller match: revokerDid (a bare DID or a
+            // did#key-fragment) authorizes when it equals a chain controller, or its bare DID
+            // does. This covers did:key (the DID *is* the key) and a did:web controller whose
+            // bare DID matches the revoker's key fragment (did:web:issuer#key-1 → did:web:issuer).
+            // It does NOT resolve the controller's DID document, so a revoker key belonging to a
+            // *different* DID that the controller would authorize is not matched.
+            // TODO: support cross-DID key authorization by resolving the controller's DID
+            // document and checking its verificationMethod/capabilityDelegation relationships.
             return chain.Any(link =>
                 link.Controller is not null &&
                 link.Controller.ContainsVerificationMethod(revokerDid));

--- a/tests/ZcapLd.Core.Tests/Compliance/NormativeIntegrationComplianceTests.cs
+++ b/tests/ZcapLd.Core.Tests/Compliance/NormativeIntegrationComplianceTests.cs
@@ -366,6 +366,11 @@ public class NormativeIntegrationComplianceTests
             new[] { "read" },
             DateTime.UtcNow.AddMonths(6));
 
-        delegated.Expires.Should().NotBeNull();
+        // Assert the requested 6-month expiration round-trips intact, not merely that no
+        // exception was thrown — this catches a silent truncation in DelegateCapabilityAsync
+        // that a NotBeNull() check would miss (PR #81 review).
+        delegated.ExpiresAt.Should().NotBeNull();
+        delegated.ExpiresAt!.Value.Should().BeCloseTo(
+            DateTime.UtcNow.AddMonths(6), TimeSpan.FromSeconds(5));
     }
 }

--- a/tests/ZcapLd.Core.Tests/Models/ControllerSetTests.cs
+++ b/tests/ZcapLd.Core.Tests/Models/ControllerSetTests.cs
@@ -170,6 +170,31 @@ public class ControllerSetTests
         set.ContainsVerificationMethod("did:example:alice#key-1").Should().BeTrue();
     }
 
+    [Fact]
+    public void ContainsVerificationMethod_MatchesKeyFragmentAgainstBareControllerDid()
+    {
+        // A revoker/invoker authenticates with a specific key fragment (did#key-1) while the
+        // capability's controller is the bare DID. The bare-DID split authorizes correctly —
+        // the relevant case for a did:web controller that lists keyed verification methods.
+        // (PR #81 review: IsRevokerAuthorizedAsync key-fragment edge case.)
+        var set = ControllerSet.FromSingle("did:web:issuer.example");
+
+        set.ContainsVerificationMethod("did:web:issuer.example#key-1").Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsVerificationMethod_DoesNotResolveCrossDidController()
+    {
+        // Documents a known limitation: authorization is a string-level controller match, NOT a
+        // DID-document resolution. A key belonging to a DIFFERENT DID — even one the controller's
+        // DID document would authorize — is not matched. Cross-DID key authorization is future
+        // work (see the TODO in VerificationService.IsRevokerAuthorizedAsync). (PR #81 review.)
+        var set = ControllerSet.FromSingle("did:web:issuer.example");
+
+        set.ContainsVerificationMethod("did:key:z6MkSomeOtherKey#z6MkSomeOtherKey")
+            .Should().BeFalse();
+    }
+
     // ─── Implicit conversions + equality ───────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Follow-up to the **merged** PR #81. Its review raised two items to address before merge; #81 merged before these fixes landed, so they ship here as a small follow-up. No production behavior change beyond comments — **364 tests green**.

## Changes

**1. Tighten the SHOULD-04 compliance test**
The test only asserted `delegated.Expires` was non-null (i.e. "no exception thrown"). It now asserts the requested 6-month expiration round-trips intact, catching a silent truncation in `DelegateCapabilityAsync`:
```csharp
delegated.ExpiresAt.Should().NotBeNull();
delegated.ExpiresAt!.Value.Should().BeCloseTo(DateTime.UtcNow.AddMonths(6), TimeSpan.FromSeconds(5));
```
(The reviewer suggested asserting on `Expires`, but that's the verbatim on-wire `string?`; the parsed `DateTime?` view is `ExpiresAt`.)

**2. Document `IsRevokerAuthorizedAsync` authorization semantics**
The review flagged a possible false-negative for `did:web` controllers with key fragments. On inspection, the cited example (`controller=did:web:issuer.example`, `revoker=did:web:issuer.example#key-1`) actually **passes** — `ContainsVerificationMethod` splits on `#`, so the bare DID matches. The real gap is **cross-DID** authorization: a revoker key belonging to a *different* DID the controller's DID document would authorize is not matched, because no DID resolution happens.

- Added a `TODO` + clarifying comment in `VerificationService.IsRevokerAuthorizedAsync` describing exactly what the string match covers and what it doesn't.
- Added two `ControllerSetTests`: one proving the key-fragment case works, one pinning the cross-DID limitation as known behavior.

## Not addressed (with reasoning)

- **Warning log for long expirations** — optional/conditional in the review. `CapabilityService` has no logger and Core has zero logging infrastructure; adding a package dependency + constructor change to land a soft suggestion is scope creep against #81's deliberate decision to enforce the ceiling on the verify path in #73.
- **Cumulative branch note** — informational only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)