### PR TITLE
fix(#74): use ordinal StartsWith in invocation-target prefix check

### DIFF
--- a/src/ZcapLd.Core/Services/VerificationService.cs
+++ b/src/ZcapLd.Core/Services/VerificationService.cs
@@ -1198,7 +1198,9 @@ public class VerificationService : IVerificationService
     /// Per spec: suffix MUST start with slash or question mark if no query exists,
     /// or ampersand when the capability target already contains a query.
     /// </summary>
-    private bool IsValidInvocationTarget(string invocationTarget, string capabilityTarget)
+    /// <remarks>Internal (not private) so the ordinal prefix matching can be unit-tested
+    /// directly; the fail-closed call sites make a black-box test indistinguishable (Issue #74).</remarks>
+    internal bool IsValidInvocationTarget(string invocationTarget, string capabilityTarget)
     {
         if (string.IsNullOrEmpty(invocationTarget) || string.IsNullOrEmpty(capabilityTarget))
             return false;
@@ -1207,8 +1209,12 @@ public class VerificationService : IVerificationService
         if (invocationTarget == capabilityTarget)
             return true;
 
-        // Check if invocationTarget is a valid prefix extension
-        if (invocationTarget.StartsWith(capabilityTarget))
+        // Check if invocationTarget is a valid prefix extension.
+        // Ordinal comparison keeps this consistent with the ordinal Substring index math
+        // below (and the ordinal `==`/char checks around it); a culture-sensitive overload
+        // can treat ignorable Unicode code points as zero-width, disagreeing on length and
+        // throwing ArgumentOutOfRangeException in the subsequent Substring (Issue #74).
+        if (invocationTarget.StartsWith(capabilityTarget, StringComparison.Ordinal))
         {
             var suffix = invocationTarget.Substring(capabilityTarget.Length);
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -68,3 +68,30 @@
 - **User correction (#71 freshness):** my approved plan listed delegation-proof `created` freshness under "Out of scope / notes" as a passive comment. The user rejected the plan: "Either implement it or create a detailed github issue. We need to keep track or fix. Not just let it linger." **Rule: a gap you discover during a fix has exactly two honest dispositions — fix it now, or file a tracked issue (with enough detail to act on later). A bullet in a plan file is neither; it evaporates when the PR merges.** I filed #99 with the distinct semantics spelled out and referenced it from the PR/CHANGELOG/AGENTS note. Offer the choice (fix-now vs track) via `AskUserQuestion` rather than deciding unilaterally.
 - **Related-but-different ≠ same fix.** Reusing #71's invocation freshness helper for delegation proofs would have been a *bug*: invocations are ephemeral (staleness lower-bound = `now - created > nonceWindow` is correct), but delegation proofs are **durable** (a months-old capability is valid until `expires`) — the same staleness bound would reject every old capability. Surfacing that distinction is what made the "track it" decision correct and gave #99 real content. When tempted to "apply the same check over there," first prove the semantics actually match.
 - **The sibling-refactor trap fired AGAIN (4th data point).** Research ran against local `main` (28a6d2d); `origin/main` had since merged **#98/#70** (structured `VerificationResult`), which rewrote `VerifyInvocationCoreAsync` from `return false` to `return VerificationResult.Fail(outcome, …)`. My plan's `return false` snippets were stale. Caught it by re-reading the target method post-branch (the standing rule held) and adapting: the freshness gate now returns `VerificationResult.Fail(VerificationOutcome.StaleProof, …)` and I added a precise `StaleProof` enum member rather than overloading `Replayed`. **Reinforced rule: fetch FIRST, then research against `origin/main` — or at minimum re-validate every research coordinate against the post-fetch file before editing.** Revocation stayed `bool` (control-plane), so its gate is a plain `return false`; match each path's existing return convention.
+
+## 2026-06-05 (issue #74) — Ablation can give a FALSE PASS through a stale linked DLL
+- **Issue #74 (no correction — self-caught):** proving the new regression guard by ablation (revert the
+  fix, expect the test to fail) initially showed the test **still passing** on the reverted code. The
+  ablation lesson from earlier today said "watch it go red" — it stayed green, and I almost trusted it.
+- **Mechanism — `--no-build` + rebuilding only the library links a stale dependency copy.** I edited
+  `VerificationService` back to culture-sensitive, ran `dotnet build src/ZcapLd.Core/...` (library only),
+  then `dotnet test --no-build`. The test project's `bin/.../ZcapLd.Core.dll` is a **copy** made at the
+  test project's last build (which had the fix); `--no-build` skips the copy, so the test ran against the
+  **stale fixed** Core, not my reverted source. False green. Same family as the standing "`--no-build`
+  runs the STALE binary" note, but a sharper form: it's the **transitively-referenced** DLL that's stale,
+  even though I *did* rebuild (just the wrong project).
+- **Rule — for ablation, rebuild the TEST project (or omit `--no-build` entirely) so it re-copies the
+  reverted dependency.** Verify the source is actually reverted in the binary under test before believing
+  a PASS/FAIL. When a deny/throw test refuses to go red under ablation, suspect a stale linked artifact
+  **before** concluding the test is wrong — confirm with an out-of-band probe.
+- **Probe the runtime claim out-of-band when a test's premise is platform-dependent.** Culture-sensitive
+  ignorable-char behavior is ICU/locale-specific, so I wrote a throwaway `dotnet run app.cs` (file-based
+  app) asserting `cap.StartsWith(cap + "­")` is culture=`true`/ordinal=`false` and that the culture
+  path's `Substring` throws. That confirmed the divergence is real on this platform **independently** of
+  the xUnit harness — which is what exposed the stale-DLL false green as a harness artifact, not a real
+  "bug doesn't reproduce here."
+- **Fail-closed callers make black-box tests blind — test the unit.** Both `IsValidInvocationTarget`
+  callers catch → `false`, so the bug (throw) and the fix (clean `false`) are indistinguishable through
+  the public bool API. Promoting the helper `private`→`internal` (repo already had
+  `InternalsVisibleTo`) to assert "returns false WITHOUT throwing" is what gives the guard teeth. When a
+  bug's only observable difference is swallowed by a catch, push the assertion below the catch.

--- a/tasks/todo-20260605-issue74-ordinal-startswith.md
+++ b/tasks/todo-20260605-issue74-ordinal-startswith.md
@@ -1,0 +1,64 @@
+# Issue #74 [L9] — Culture-sensitive `StartsWith` in invocation-target prefix check
+
+Branch: `74-ordinal-startswith-invocation-target` (off refreshed `main` @ `b786566`, after fetch+rebase).
+
+## Problem (confirmed still open before fixing)
+`VerificationService.IsValidInvocationTarget` tested the prefix with the culture-sensitive
+`string.StartsWith(string)` overload, while the surrounding logic — the `==` exact-match, the
+following `Substring(capabilityTarget.Length)` index math, and the `StartsWith(char)` suffix checks —
+is all ordinal. With an ignorable Unicode code point (e.g. U+00AD SOFT HYPHEN) the culture-sensitive
+comparison disagrees on length; when the capability target is ordinally **longer** than the invocation
+target it returns `true` and the subsequent `Substring` indexes past the end → `ArgumentOutOfRangeException`.
+Both call sites (invocation verify, delegation attenuation) are fail-closed (catch → `false`), and real
+targets are ASCII URIs, so impact is **low** — a latent correctness/consistency bug.
+
+Confirmed at fix time: the line had moved (issue cited `:556` @ `core-v2.1.1`) but was byte-identical;
+it was the **only** culture-sensitive `StartsWith(string)` in `src/`.
+
+## Fix (minimal)
+`src/ZcapLd.Core/Services/VerificationService.cs` — one comparison:
+```csharp
+if (invocationTarget.StartsWith(capabilityTarget, StringComparison.Ordinal))
+```
+For all real ASCII URIs ordinal and culture-sensitive agree, so **no legitimate behavior changes**;
+only the pathological Unicode path is corrected (and the `ArgumentOutOfRangeException` corner case removed).
+Also changed `IsValidInvocationTarget` from `private` → `internal` (repo already has
+`InternalsVisibleTo ZcapLd.Core.Tests`) so the prefix logic can be unit-tested directly — the
+fail-closed call sites make a black-box test indistinguishable.
+
+## Tasks
+- [x] Branch off refreshed `origin/main` (fetch + rebase), re-read target file (line moved 556→1211)
+- [x] One-line ordinal fix + explanatory comment
+- [x] `IsValidInvocationTarget` `private` → `internal` for direct unit testing
+- [x] Regression tests: `VerificationServiceTests.cs` — 8 tests (4 valid-prefix theory, 3 invalid-prefix
+      theory, 1 `ArgumentOutOfRangeException` guard `Fact`)
+- [x] Build green (solution, 0 errors)
+- [x] **Ablation**: reverted to culture-sensitive, rebuilt the TEST project (not just Core), confirmed
+      the guard `Fact` FAILS with the exact `ArgumentOutOfRangeException` from the issue; restored fix
+- [x] Full suite green (Core 486, AspNetCore 6, 0 failures)
+- [x] Review section + lesson
+
+## Verification
+- **Empirical probe** (.NET 10 / macOS / en-US / ICU): for U+00AD (and U+200B/U+FEFF/U+200C/U+2060/U+0001),
+  `cap.StartsWith(cap + ignorable)` returns culture=`true` / ordinal=`false`, and the culture path's
+  `Substring` throws `ArgumentOutOfRangeException`. The divergence is real on this platform.
+- **Ablation proves the guard**: with the fix reverted (and the *test project* rebuilt so it links the
+  reverted Core — see lesson), the guard `Fact` fails with
+  `ArgumentOutOfRangeException: startIndex cannot be larger than length of string` at the `Substring`.
+  With the fix, all 8 pass. The 7 non-throwing controls pass on both versions (behavior-locking).
+- **No regression**: 486 Core + 6 AspNetCore tests pass.
+
+## Review (2026-06-05)
+One-line ordinal fix, exactly as the issue recommended; the only nuance was making the prefix helper
+`internal` so the regression test can target it directly (the fail-closed callers swallow the bug into a
+bare `false`, so a black-box test can't tell the fix from the bug). The guard test was proven by ablation
+— and that ablation initially gave a **false PASS** because I rebuilt only `ZcapLd.Core` and ran the tests
+with `--no-build`, so the test project linked the *stale fixed* `ZcapLd.Core.dll` already copied into its
+`bin`. Rebuilding the test project (omitting `--no-build`) surfaced the real failure. Captured in lessons.
+
+**Files:** `src/ZcapLd.Core/Services/VerificationService.cs` (ordinal comparison + visibility +
+comments), `tests/ZcapLd.Core.Tests/Services/VerificationServiceTests.cs` (+8 tests). No public API,
+wire-format, or doc-surface change (internal behavior only) → README/ARCHITECTURE untouched.
+
+**Not done (left to user):** GitHub issue #74 not closed/commented — awaiting review. Branch not
+committed/pushed (repo policy: commit only when asked).

--- a/tests/ZcapLd.Core.Tests/Services/VerificationServiceTests.cs
+++ b/tests/ZcapLd.Core.Tests/Services/VerificationServiceTests.cs
@@ -1737,6 +1737,57 @@ public class VerificationServiceTests
     }
 
     #endregion
+
+    #region Invocation Target Prefix Matching (Issue #74 — ordinal StartsWith)
+
+    // IsValidInvocationTarget must test the prefix ordinally, consistent with the ordinal Substring
+    // index math that follows it. A culture-sensitive StartsWith treats ignorable Unicode code points
+    // (e.g. U+00AD SOFT HYPHEN) as zero-width, which disagrees with the ordinal length used by
+    // Substring — and, when the capability target is ordinally longer than the invocation target,
+    // drives Substring past the end of the string (ArgumentOutOfRangeException). These exercise the
+    // method directly: the call sites are fail-closed (catch → false), so a black-box test cannot
+    // distinguish the ordinal fix from the buggy culture-sensitive comparison.
+
+    [Theory]
+    [InlineData("https://example.com/resource", "https://example.com/resource")]             // exact match
+    [InlineData("https://example.com/resource/sub", "https://example.com/resource")]         // path suffix
+    [InlineData("https://example.com/resource?q=1", "https://example.com/resource")]         // query suffix
+    [InlineData("https://example.com/resource?a=1&b=2", "https://example.com/resource?a=1")] // extra query param after '?'
+    public void IsValidInvocationTarget_ValidPrefixes_ReturnsTrue(string invocationTarget, string capabilityTarget)
+    {
+        _verificationService.IsValidInvocationTarget(invocationTarget, capabilityTarget)
+            .Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("https://example.com/resource", "https://other.com/resource")]               // different host
+    [InlineData("https://example.com/resourceX", "https://example.com/resource")]            // suffix lacks a delimiter
+    [InlineData("https://example.com/re\u00ADsource/x", "https://example.com/resource")]     // ignorable char breaks the ordinal prefix
+    public void IsValidInvocationTarget_InvalidPrefixes_ReturnsFalse(string invocationTarget, string capabilityTarget)
+    {
+        _verificationService.IsValidInvocationTarget(invocationTarget, capabilityTarget)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidInvocationTarget_CapabilityTargetOrdinallyLongerViaIgnorableChar_ReturnsFalseWithoutThrowing()
+    {
+        // The capability target carries a trailing SOFT HYPHEN (U+00AD), making it ordinally LONGER
+        // than the invocation target. The pre-#74 culture-sensitive StartsWith returns true (the soft
+        // hyphen is ignorable), after which Substring(capabilityTarget.Length) runs past the end of the
+        // shorter invocation target and throws ArgumentOutOfRangeException. Ordinal comparison returns
+        // false cleanly — this is the deterministic regression guard for Issue #74.
+        var invocationTarget = "https://example.com/resource";
+        var capabilityTarget = "https://example.com/resource\u00AD";
+
+        var result = true;
+        var act = () => { result = _verificationService.IsValidInvocationTarget(invocationTarget, capabilityTarget); };
+
+        act.Should().NotThrow("ordinal comparison must not index Substring past the end of the shorter target");
+        result.Should().BeFalse();
+    }
+
+    #endregion
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #74.

## Summary
`VerificationService.IsValidInvocationTarget` tested the prefix with the **culture-sensitive** `string.StartsWith(string)` overload, while the surrounding logic is all **ordinal** — the `==` exact-match, the following `Substring(capabilityTarget.Length)` index math, and the `StartsWith(char)` suffix checks. With an ignorable Unicode code point (e.g. U+00AD soft hyphen) the culture-sensitive comparison disagrees on length; when the capability target is ordinally *longer* than the invocation target it returns `true` and the subsequent `Substring` indexes past the end → `ArgumentOutOfRangeException`.

Both call sites (invocation verify, delegation attenuation) are fail-closed, and real targets are ASCII URIs, so impact is **low** — a latent correctness/consistency bug.

## Fix
```diff
-        if (invocationTarget.StartsWith(capabilityTarget))
+        if (invocationTarget.StartsWith(capabilityTarget, StringComparison.Ordinal))
```
For all real ASCII URIs ordinal and culture-sensitive agree, so there is **no behavior change** for legitimate input; only the pathological Unicode path is corrected and the `ArgumentOutOfRangeException` corner case removed.

`IsValidInvocationTarget` is promoted `private` → `internal` (the repo already has `InternalsVisibleTo ZcapLd.Core.Tests`) so the prefix logic can be unit-tested directly — the fail-closed callers swallow the bug into a bare `false`, making a black-box test unable to distinguish the fix from the bug.

## Tests (8 new)
- 4 valid-prefix cases (exact, path suffix, query suffix, extra `&` param) → `true`
- 3 invalid-prefix cases (different host, suffix without a delimiter, ignorable char breaking the ordinal prefix) → `false`
- 1 guard `Fact`: capability target ordinally longer via a trailing U+00AD must return `false` **without throwing**

**Proven by ablation:** with the fix reverted to the culture-sensitive overload (and the test project rebuilt so it links the reverted `ZcapLd.Core` — not run with `--no-build`, which would link the stale fixed copy), the guard `Fact` fails with the exact `ArgumentOutOfRangeException: startIndex cannot be larger than length of string` from the issue. With the fix, all 8 pass; the 7 non-throwing controls pass on both versions.

## Verification
- Full suite green: **486 Core + 6 AspNetCore**, 0 failures.
- An out-of-band probe (.NET 10 / macOS / en-US / ICU) confirmed the divergence is real on this platform for U+00AD and other ignorable code points.

No public API, wire-format, or documentation-surface change (internal behavior only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)