### PR TITLE
chore(release): finalize 4.0.0 CHANGELOG (release prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [4.0.0] - Unreleased
+## [4.0.0] - 2026-06-19
 
 Delegates zcap's cryptography and canonicalization to the composable foundation (issue #108) and
 makes the wire format interoperable with the `@digitalbazaar/zcap` reference implementation.
-Includes everything in the (unreleased) 3.0.0 section below.
+Includes everything in the 3.0.0 section below (which was never released as a separate version).
 
 ### Added
 
@@ -68,7 +68,7 @@ Remediation of a multi-agent security + W3C ZCAP-LD compliance scan (28 confirme
 
 - **Capabilities issued by 3.x still verify — no re-delegation.** The `Ed25519Signature2020` / `EcdsaSecp256r1Signature2019` proof bytes are unchanged. A golden-vector suite (`tests/ZcapLd.Core.Tests/Compliance/ProofGoldenVectorTests`, `CanonicalizationGoldenVectorTests`) pins the deterministic `proofValue`, the RDFC N-Quads + hash-concat payload, and the JCS null-skip behavior byte-for-byte across the swaps.
 
-## [3.0.0] - Unreleased
+## [3.0.0] - Folded into 4.0.0 (never released separately)
 
 ### Breaking Changes
 


### PR DESCRIPTION
Release prep for **4.0.0**. Only change: date the CHANGELOG `4.0.0` section (`2026-06-19`) and mark the never-separately-released `3.0.0` section as folded into 4.0.0. `ZcapLdVersion` is already `4.0.0`.

**Pack preflight (verified locally, per `docs/NUGET-RELEASE.md`):** clean → `build --no-incremental` → `pack --no-build` produced `ZcapLd.Core.4.0.0` + `ZcapLd.AspNetCore.4.0.0` (+ symbols); nuspecs both `4.0.0`; AspNetCore → Core `4.0.0` (synchronized); deps pinned `DataProofs 1.0.1`, `NetDid 2.0.1`. Full suite green; interop harness 12/12.

## To publish (maintainer)
After merge, tag both packages (per the runbook):
```
git tag core-v4.0.0   && git push origin core-v4.0.0
git tag aspnet-v4.0.0 && git push origin aspnet-v4.0.0
```

---

## Draft release notes (paste into the GitHub Release)

### zcap-dotnet 4.0.0

Major release: **full, live-proven wire interoperability with the W3C ZCAP-LD reference implementation `@digitalbazaar/zcap`**, plus the migration onto the composable crypto/canonicalization stack.

**Highlights**
- Interop with `@digitalbazaar/zcap` proven end-to-end — capability **delegation** (single + multi-level) and Data Integrity **invocation** (root + delegated), **both directions**, via the `interop/` harness (12 checks).
- **RDFC-1.0 is the only canonicalization** (JCS removed) — the format that interoperates.
- Crypto/canonicalization delegated to **NetCrypto + DataProofs + NetCid**.
- W3C MUST closeouts on the verify path (`@context` value + root invariants); `allowedAction` omit-to-widen fixed; root-id `encodeURIComponent` parity.

**⚠️ Breaking**
- JCS removed; `canonicalizationMethod` param / `AddZcapRdfcCanonicalization()` / `JcsDocumentCanonicalizer` gone — JCS-signed zcaps from ≤3.x must be re-signed under RDFC-1.0.
- `NetDid.Core.Crypto.*` types → `NetCrypto.*` (recompile); crypto-suite extension surface removed (fixed Ed25519 / P-256 set).
- Wire: root referenced by id in `capabilityChain` (#50); `Invocation.Capability` / `Proof.Capability` typed (#51).
- Security note: signed revocation `reason`/`metadata` are informational (not tamper-bound) under RDFC.

**Added**
- `@digitalbazaar/zcap`-compatible Data Integrity invocations: `SignCapabilityInvocationAsync` / `VerifyCapabilityInvocationAsync` (the verifier requires the relying party's `expectedAction`/`expectedTargets` and validates the application-document `@context` — both adversarial-review security gates).

**Known follow-ups**
- HTTP-Signature invocations (ezcap "Path B") — #119.
- Verify-path robustness for unknown caveat types — #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)