### PR TITLE
Bump net-did 2.0.1→2.2.0 and NetCrypto 1.1.0→1.2.0 (v4.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.1.0] - 2026-07-13
+
+Foundation-pin bump only (issue #127) so a consumer graph can converge cleanly at net-did 2.2.0 /
+NetCrypto 1.2.0 — required for `net-wallet-sdk` 0.2.0's identity document-update / key-rotation
+integrity contract (FR-ID-10), which depends on net-did 2.2.0's `DidUpdateResult` evidence. No source,
+API, or wire changes; capabilities issued by 4.0.0 verify unchanged.
+
+### Changed
+
+- **Dependencies — foundation pins bumped (additive).** `NetDid.Core` / `NetDid.Method.Key`
+  **2.0.1 → 2.2.0** and `NetCrypto` **1.1.0 → 1.2.0**. The surfaces ZcapLd uses (DID resolution,
+  `did:key`) are unchanged; net-did 2.2.0's new `DidUpdateResult` members are nullable additions.
+  Restore is clean (no `NU1605` downgrade) and the full suite (464 Core + 33 AspNetCore) is green.
+
 ## [4.0.0] - 2026-06-19
 
 Delegates zcap's cryptography and canonicalization to the composable foundation (issue #108) and

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,10 @@
          (via NetDid 2.0.0), DataProofs.Rdfc, and NetCid JCS. Source-breaking (consumers
          recompile; NetDid.Core.Crypto types moved to NetCrypto) but WIRE-COMPATIBLE — the
          Ed25519Signature2020 / EcdsaSecp256r1Signature2019 proof bytes are unchanged, so
-         capabilities issued by 3.x still verify. -->
-    <ZcapLdVersion>4.0.0</ZcapLdVersion>
+         capabilities issued by 3.x still verify.
+         4.1.0 (#127): foundation pin bump only — NetDid.* 2.0.1 → 2.2.0 and NetCrypto
+         1.1.0 → 1.2.0 (additive; downstream convergence for net-wallet-sdk 0.2.0). No
+         source or wire changes. -->
+    <ZcapLdVersion>4.1.0</ZcapLdVersion>
   </PropertyGroup>
 </Project>

--- a/interop/ZcapLd.Interop/ZcapLd.Interop.csproj
+++ b/interop/ZcapLd.Interop/ZcapLd.Interop.csproj
@@ -18,8 +18,8 @@
   <ItemGroup>
     <ProjectReference Include="../../src/ZcapLd.Core/ZcapLd.Core.csproj" />
     <!-- Direct refs for the in-harness deterministic DID provider (mirrors the test helper). -->
-    <PackageReference Include="NetCrypto" Version="1.1.0" />
-    <PackageReference Include="NetDid.Core" Version="2.0.1" />
+    <PackageReference Include="NetCrypto" Version="1.2.0" />
+    <PackageReference Include="NetDid.Core" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ZcapLd.Core/ZcapLd.Core.csproj
+++ b/src/ZcapLd.Core/ZcapLd.Core.csproj
@@ -48,7 +48,7 @@
          for raw sign/verify in CryptoSuite. NetCrypto's ECDSA Sign/Verify default to DER, but the
          W3C `ecdsa-2019` suite requires IEEE P1363 (fixed-width r||s), so CryptoSuite calls the
          format-aware overloads with EcdsaSignatureFormat.IeeeP1363. See CryptoSuite.cs. -->
-    <PackageReference Include="NetCrypto" Version="1.1.0" />
+    <PackageReference Include="NetCrypto" Version="1.2.0" />
     <!-- Data Integrity proof machinery: RDFC-1.0 / JSON-LD canonicalization (DataProofsDotnet.Rdfc)
          and the legacy Linked-Data-Signature cryptosuites — Ed25519Signature2020 /
          EcdsaSecp256r1Signature2019 — that sign/verify zcap's 2020-era wire convention
@@ -58,8 +58,8 @@
     <PackageReference Include="DataProofsDotnet.Rdfc" Version="1.1.0" />
     <PackageReference Include="DataProofsDotnet.Legacy" Version="1.0.1" />
     <!-- W3C DID Core and did:key method (DID resolution; crypto via NetCrypto). -->
-    <PackageReference Include="NetDid.Core" Version="2.0.1" />
-    <PackageReference Include="NetDid.Method.Key" Version="2.0.1" />
+    <PackageReference Include="NetDid.Core" Version="2.2.0" />
+    <PackageReference Include="NetDid.Method.Key" Version="2.2.0" />
 
     <!-- Logging abstraction only: lets the verifier emit a diagnostic when it fails closed,
          so a misconfiguration/transient fault is distinguishable from an invalid capability


### PR DESCRIPTION
Closes #127.

## Summary

Foundation-pin bump only so a consumer graph can converge cleanly at **net-did 2.2.0 / NetCrypto 1.2.0** — required for `net-wallet-sdk` 0.2.0's identity document-update / key-rotation integrity contract (FR-ID-10), which depends on net-did 2.2.0's `DidUpdateResult` evidence. No source, API, or wire changes; capabilities issued by 4.0.0 verify unchanged.

## Changes

| File | Change |
|------|--------|
| `src/ZcapLd.Core/ZcapLd.Core.csproj` | NetCrypto `1.1.0→1.2.0`, NetDid.Core & NetDid.Method.Key `2.0.1→2.2.0` |
| `interop/ZcapLd.Interop/ZcapLd.Interop.csproj` | NetCrypto `1.1.0→1.2.0`, NetDid.Core `2.0.1→2.2.0` |
| `Directory.Build.props` | `ZcapLdVersion` `4.0.0→4.1.0` |
| `CHANGELOG.md` | New `[4.1.0]` section |

Pinned the exact **2.2.0 / 1.2.0** the issue requests (not the newer 2.3.0 line on nuget.org) — the goal is convergence with net-wallet-sdk 0.2.0's net-did 2.2.0 pin.

## Verification (acceptance criteria)

- ✅ Clean restore — **no NU1605** downgrade. Resolved transitive graph converges: NetCrypto `1.2.0`, NetDid.Core `2.2.0`, NetDid.Method.Key `2.2.0` (DataProofs/NetDid do not hold NetCrypto down).
- ✅ Build `-c Release`: 0 errors.
- ✅ Full suite green: **497 tests** (464 Core + 33 AspNetCore), 0 failed.
- ✅ Standalone interop harness still builds.

**Note on lock files:** the issue's `dotnet restore --locked-mode` / `packages.lock.json` step is N/A — this repo doesn't use lock files (no `RestorePackagesWithLockFile`, none present), so there's nothing to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)