### PR TITLE
Bump DataProofs 1.1.1 and NetCrypto 1.4.0 (v4.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.1.1] - 2026-07-27
+
+Dependency bump only. No source, API, or wire changes — the golden-vector proof and canonicalization
+suites confirm the `Ed25519Signature2020` / `EcdsaSecp256r1Signature2019` proof bytes are
+byte-identical, so capabilities issued by 4.1.0 verify unchanged.
+
+### Changed
+
+- **Dependencies — DataProofs and NetCrypto bumped.** `DataProofsDotnet.Core` / `DataProofsDotnet.Rdfc`
+  **1.1.0 → 1.1.1**, `DataProofsDotnet.Legacy` **1.0.1 → 1.1.1**, and `NetCrypto` **1.2.0 → 1.4.0**.
+  Restore is clean (no `NU1605` downgrade), the resolved graph converges (DataProofs 1.1.1, NetCrypto
+  1.4.0), and the full suite (464 Core + 33 AspNetCore) is green. `NetDid.*` stays at **2.2.0** (the
+  #127 convergence pin) pending the NetDid 3.0.0 line; NetDid 2.2.0 remains compatible with NetCrypto
+  1.4.0.
+
 ## [4.1.0] - 2026-07-13
 
 Foundation-pin bump only (issue #127) so a consumer graph can converge cleanly at net-did 2.2.0 /

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,11 @@
          capabilities issued by 3.x still verify.
          4.1.0 (#127): foundation pin bump only — NetDid.* 2.0.1 → 2.2.0 and NetCrypto
          1.1.0 → 1.2.0 (additive; downstream convergence for net-wallet-sdk 0.2.0). No
-         source or wire changes. -->
-    <ZcapLdVersion>4.1.0</ZcapLdVersion>
+         source or wire changes.
+         4.1.1: dependency bump — DataProofsDotnet.* Core/Rdfc 1.1.0 → 1.1.1, Legacy
+         1.0.1 → 1.1.1, and NetCrypto 1.2.0 → 1.4.0 (NetDid stays 2.2.0 pending the
+         NetDid 3.0.0 line). Dependency-only; proof/canonicalization wire bytes unchanged
+         (pinned by the golden-vector suite). -->
+    <ZcapLdVersion>4.1.1</ZcapLdVersion>
   </PropertyGroup>
 </Project>

--- a/interop/ZcapLd.Interop/ZcapLd.Interop.csproj
+++ b/interop/ZcapLd.Interop/ZcapLd.Interop.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="../../src/ZcapLd.Core/ZcapLd.Core.csproj" />
     <!-- Direct refs for the in-harness deterministic DID provider (mirrors the test helper). -->
-    <PackageReference Include="NetCrypto" Version="1.2.0" />
+    <PackageReference Include="NetCrypto" Version="1.4.0" />
     <PackageReference Include="NetDid.Core" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/ZcapLd.Core/ZcapLd.Core.csproj
+++ b/src/ZcapLd.Core/ZcapLd.Core.csproj
@@ -48,15 +48,15 @@
          for raw sign/verify in CryptoSuite. NetCrypto's ECDSA Sign/Verify default to DER, but the
          W3C `ecdsa-2019` suite requires IEEE P1363 (fixed-width r||s), so CryptoSuite calls the
          format-aware overloads with EcdsaSignatureFormat.IeeeP1363. See CryptoSuite.cs. -->
-    <PackageReference Include="NetCrypto" Version="1.2.0" />
+    <PackageReference Include="NetCrypto" Version="1.4.0" />
     <!-- Data Integrity proof machinery: RDFC-1.0 / JSON-LD canonicalization (DataProofsDotnet.Rdfc)
          and the legacy Linked-Data-Signature cryptosuites — Ed25519Signature2020 /
          EcdsaSecp256r1Signature2019 — that sign/verify zcap's 2020-era wire convention
          (DataProofsDotnet.Legacy). DataProofsDotnet.Core arrives transitively but is listed for
          clarity. See LegacyProofCrypto.cs. -->
-    <PackageReference Include="DataProofsDotnet.Core" Version="1.1.0" />
-    <PackageReference Include="DataProofsDotnet.Rdfc" Version="1.1.0" />
-    <PackageReference Include="DataProofsDotnet.Legacy" Version="1.0.1" />
+    <PackageReference Include="DataProofsDotnet.Core" Version="1.1.1" />
+    <PackageReference Include="DataProofsDotnet.Rdfc" Version="1.1.1" />
+    <PackageReference Include="DataProofsDotnet.Legacy" Version="1.1.1" />
     <!-- W3C DID Core and did:key method (DID resolution; crypto via NetCrypto). -->
     <PackageReference Include="NetDid.Core" Version="2.2.0" />
     <PackageReference Include="NetDid.Method.Key" Version="2.2.0" />


### PR DESCRIPTION
## Summary

Dependency bump only (v4.1.1). No source, API, or wire changes; capabilities issued by 4.1.0 verify unchanged.

- `DataProofsDotnet.Core` / `.Rdfc` **1.1.0 → 1.1.1**, `.Legacy` **1.0.1 → 1.1.1**
- `NetCrypto` **1.2.0 → 1.4.0** (Core + interop harness)
- `NetDid.*` stays at **2.2.0** (the #127 convergence pin) pending the NetDid 3.0.0 line — NetDid 2.2.0 remains compatible with NetCrypto 1.4.0
- `ZcapLdVersion` **4.1.0 → 4.1.1**

## Changes

| File | Change |
|------|--------|
| `src/ZcapLd.Core/ZcapLd.Core.csproj` | DataProofs → 1.1.1, NetCrypto 1.2.0 → 1.4.0 |
| `interop/ZcapLd.Interop/ZcapLd.Interop.csproj` | NetCrypto 1.2.0 → 1.4.0 |
| `Directory.Build.props` | `ZcapLdVersion` 4.1.0 → 4.1.1 |
| `CHANGELOG.md` | New `[4.1.1]` section |

## Verification

- ✅ Clean restore — **no NU1605** downgrade. The direct `NetCrypto 1.4.0` reference wins over NetDid 2.2.0's transitive floor.
- ✅ Resolved graph: DataProofs `1.1.1`, NetCrypto `1.4.0`, NetDid.Core / NetDid.Method.Key `2.2.0`.
- ✅ Build `-c Release`: 0 errors.
- ✅ Full suite green: **497 tests** (464 Core + 33 AspNetCore), 0 failed.
- ✅ Golden-vector proof + canonicalization suites confirm `Ed25519Signature2020` / `EcdsaSecp256r1Signature2019` proof bytes are byte-identical (no wire regression).

## Notes

- Kept as a **4.1.1 patch**: NetCrypto 1.2→1.4 is a minor dependency bump, dependency-only with no zcap API/wire change.
- NetDid deliberately held at 2.2.0 "for now" — the NetDid 3.0.0 upgrade will be a separate, larger change (likely its own version decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)