### PR TITLE
Bump NetDid 2.2.0 → 3.0.0 (v4.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.2.0] - 2026-07-28
+
+Foundation bump to NetDid 3.0.0 (adds `did:ethr` support upstream). Shipped as a **minor**, not a major:
+NetDid 3.0.0 is source-compatible with 2.x for consumers, zcap's own public API compiles identically,
+and the golden-vector proof + canonicalization suites confirm the `Ed25519Signature2020` /
+`EcdsaSecp256r1Signature2019` proof bytes are byte-identical — capabilities issued by 4.1.x verify
+unchanged.
+
+### Changed
+
+- **Dependencies — NetDid bumped to 3.0.0.** `NetDid.Core` / `NetDid.Method.Key` **2.2.0 → 3.0.0**
+  (upstream adds `did:ethr` and pulls in its supporting deps — e.g. `Microsoft.IdentityModel.Tokens` —
+  transitively). NetDid 3.0.0's `NetCrypto` floor is **1.4.0**, which zcap already pins (from 4.1.1), so
+  there is no `NetCrypto` change and no `NU1605` downgrade. The surfaces zcap uses (DID resolution,
+  `did:key`, `IVerificationRelationshipResolver`) are unchanged; `did:ethr` is a new method zcap does
+  not itself consume. Resolved graph: NetDid.* 3.0.0, NetCrypto 1.4.0, DataProofs 1.1.1. Restore clean,
+  full suite green (464 Core + 33 AspNetCore).
+
 ## [4.1.1] - 2026-07-27
 
 Dependency bump only. No source, API, or wire changes — the golden-vector proof and canonicalization

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,11 @@
          4.1.1: dependency bump — DataProofsDotnet.* Core/Rdfc 1.1.0 → 1.1.1, Legacy
          1.0.1 → 1.1.1, and NetCrypto 1.2.0 → 1.4.0 (NetDid stays 2.2.0 pending the
          NetDid 3.0.0 line). Dependency-only; proof/canonicalization wire bytes unchanged
-         (pinned by the golden-vector suite). -->
-    <ZcapLdVersion>4.1.1</ZcapLdVersion>
+         (pinned by the golden-vector suite).
+         4.2.0: NetDid.* 2.2.0 → 3.0.0 (adds did:ethr support; NetCrypto floor stays
+         1.4.0, already pinned). Minor, not major — NetDid 3.0.0 is source-compatible
+         with 2.x for consumers; zcap's own public API compiles identically and the
+         proof/canonicalization wire bytes are unchanged. -->
+    <ZcapLdVersion>4.2.0</ZcapLdVersion>
   </PropertyGroup>
 </Project>

--- a/interop/ZcapLd.Interop/ZcapLd.Interop.csproj
+++ b/interop/ZcapLd.Interop/ZcapLd.Interop.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="../../src/ZcapLd.Core/ZcapLd.Core.csproj" />
     <!-- Direct refs for the in-harness deterministic DID provider (mirrors the test helper). -->
     <PackageReference Include="NetCrypto" Version="1.4.0" />
-    <PackageReference Include="NetDid.Core" Version="2.2.0" />
+    <PackageReference Include="NetDid.Core" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ZcapLd.Core/ZcapLd.Core.csproj
+++ b/src/ZcapLd.Core/ZcapLd.Core.csproj
@@ -58,8 +58,8 @@
     <PackageReference Include="DataProofsDotnet.Rdfc" Version="1.1.1" />
     <PackageReference Include="DataProofsDotnet.Legacy" Version="1.1.1" />
     <!-- W3C DID Core and did:key method (DID resolution; crypto via NetCrypto). -->
-    <PackageReference Include="NetDid.Core" Version="2.2.0" />
-    <PackageReference Include="NetDid.Method.Key" Version="2.2.0" />
+    <PackageReference Include="NetDid.Core" Version="3.0.0" />
+    <PackageReference Include="NetDid.Method.Key" Version="3.0.0" />
 
     <!-- Logging abstraction only: lets the verifier emit a diagnostic when it fails closed,
          so a misconfiguration/transient fault is distinguishable from an invalid capability


### PR DESCRIPTION
## Summary

Foundation bump to **NetDid 3.0.0**, which adds `did:ethr` support upstream (and updated its own dependencies). Shipped as a **minor (4.2.0)**, not a major — NetDid 3.0.0 is source-compatible with 2.x for consumers, zcap's own public API compiles identically, and the proof/canonicalization wire bytes are byte-identical, so capabilities issued by 4.1.x verify unchanged.

- `NetDid.Core` / `NetDid.Method.Key` **2.2.0 → 3.0.0** (Core + interop harness)
- `NetCrypto` **unchanged at 1.4.0** — exactly NetDid 3.0.0's declared floor (pinned since 4.1.1), so no `NU1605` downgrade
- `did:ethr`'s supporting deps (`Microsoft.IdentityModel.Tokens`, `System.Formats.Cbor`, `Newtonsoft.Json`, …) arrive transitively; nothing for zcap to pin directly
- `ZcapLdVersion` **4.1.1 → 4.2.0**

## Changes

| File | Change |
|------|--------|
| `src/ZcapLd.Core/ZcapLd.Core.csproj` | NetDid.Core / NetDid.Method.Key 2.2.0 → 3.0.0 |
| `interop/ZcapLd.Interop/ZcapLd.Interop.csproj` | NetDid.Core 2.2.0 → 3.0.0 |
| `Directory.Build.props` | `ZcapLdVersion` 4.1.1 → 4.2.0 |
| `CHANGELOG.md` | New `[4.2.0]` section |

## Why minor, not major

zcap's public API compiles **identically** against NetDid 3.0.0 and the wire format is unchanged. NetDid 3.0.0 is source-compatible with 2.x for direct consumers, and `did:ethr` is a new method zcap does not itself consume — so this is additive from every angle zcap exposes.

## Verification

- ✅ Clean restore — **no NU1605**. NetDid 3.0.0's `NetCrypto` floor is 1.4.0, already our pin.
- ✅ Resolved graph: NetDid.* `3.0.0`, NetCrypto `1.4.0`, DataProofs `1.1.1`.
- ✅ Build `-c Release`: **0 errors** (only pre-existing XML-doc/example warnings).
- ✅ Full suite green: **497 tests** (464 Core + 33 AspNetCore), 0 failed.
- ✅ Golden-vector proof + canonicalization suites confirm `Ed25519Signature2020` / `EcdsaSecp256r1Signature2019` proof bytes are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)